### PR TITLE
External link

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <artifactId>digipost-data-types</artifactId>
-    <version>0.5-SNAPSHOT</version>
+    <version>0.5</version>
     <name>${project.artifactId}</name>
     <description>Data types for Digipost Messages</description>
 
@@ -199,6 +199,6 @@
         <connection>scm:git:git@github.com:digipost/digipost-data-types.git</connection>
         <developerConnection>scm:git:git@github.com:digipost/digipost-data-types.git</developerConnection>
         <url>scm:git:git@github.com:digipost/digipost-data-types</url>
-        <tag>HEAD</tag>
+        <tag>0.5</tag>
     </scm>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <artifactId>digipost-data-types</artifactId>
-    <version>0.5</version>
+    <version>0.6-SNAPSHOT</version>
     <name>${project.artifactId}</name>
     <description>Data types for Digipost Messages</description>
 
@@ -199,6 +199,6 @@
         <connection>scm:git:git@github.com:digipost/digipost-data-types.git</connection>
         <developerConnection>scm:git:git@github.com:digipost/digipost-data-types.git</developerConnection>
         <url>scm:git:git@github.com:digipost/digipost-data-types</url>
-        <tag>0.5</tag>
+        <tag>HEAD</tag>
     </scm>
 </project>

--- a/readme.md
+++ b/readme.md
@@ -82,7 +82,6 @@ An external URL, along with an optional description and deadline for resources s
 |deadline|ZonedDateTime|no|ISO8601 full DateTime. After the deadline, the button with the external url will be deactivated.|
 |description|String|no|A short, optional text-field, describing the external url.|
 |buttonText|String|no|The text which will be displayed on the button which links the user to the url-field.|
-|sendersReference|String|no|Optional reference to a customer or case in the sender's system|
 
 ### XML
 
@@ -93,7 +92,6 @@ An external URL, along with an optional description and deadline for resources s
     <deadline>2017-09-30T13:37:00+02:00</deadline>
     <description>Oslo Kommune ber deg akseptere eller avslå tilbudet om barnehageplass.</description>
     <button-text>Svar på barnehageplass</button-text>
-    <sendersReference>ee50447d-11ca-46bf-bb33-d6edf0e8aef7</sendersReference>
 </externalLink>
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -78,7 +78,7 @@ An external URL, along with an optional description and deadline for resources s
 
 |Name|Type|Required|Description|
 |----|----|--------|-----------|
-|url|String|yes||
+|url|String|yes|Target URL of this link. Must be https://|
 |deadline|ZonedDateTime|no|ISO8601 full DateTime. After the deadline, the button with the external url will be deactivated.|
 |description|String|no|A short, optional text-field, describing the external url.|
 |buttonText|String|no|The text which will be displayed on the button which links the user to the url-field.|

--- a/readme.md
+++ b/readme.md
@@ -78,25 +78,22 @@ An external URL, along with an optional description and deadline for resources s
 
 |Name|Type|Required|Description|
 |----|----|--------|-----------|
-|uuid|String|yes||
 |url|String|yes||
 |deadline|ZonedDateTime|no|ISO8601 full DateTime. After the deadline, the button with the external url will be deactivated.|
 |description|String|no|A short, optional text-field, describing the external url.|
 |buttonText|String|no|The text which will be displayed on the button which links the user to the url-field.|
-|urlIsActive|Boolean|no|A status indicating whether the button and URL will be available to the user or not.|
+|sendersReference|String|no|Optional reference to a customer or case in the sender's system|
 
 ### XML
 
 ```xml
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <externalLink xmlns="http://api.digipost.no/schema/datatypes">
-    <uuid>e408313a-1a77-43af-85cf-f0548c8a1d0f</uuid>
     <url>https://www.oslo.kommune.no/barnehage/svar-pa-tilbud-om-plass/</url>
     <deadline>2017-09-30T13:37:00+02:00</deadline>
     <description>Oslo Kommune ber deg akseptere eller avslå tilbudet om barnehageplass.</description>
     <button-text>Svar på barnehageplass</button-text>
-    <url-is-active>true</url-is-active>
-    <expired>true</expired>
+    <sendersReference>ee50447d-11ca-46bf-bb33-d6edf0e8aef7</sendersReference>
 </externalLink>
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -78,7 +78,7 @@ An external URL, along with an optional description and deadline for resources s
 
 |Name|Type|Required|Description|
 |----|----|--------|-----------|
-|url|String|yes|Target URL of this link. Must be https://|
+|url|String|yes|Target URL of this link.|
 |deadline|ZonedDateTime|no|ISO8601 full DateTime. After the deadline, the button with the external url will be deactivated.|
 |description|String|no|A short, optional text-field, describing the external url.|
 |buttonText|String|no|The text which will be displayed on the button which links the user to the url-field.|

--- a/readme.md
+++ b/readme.md
@@ -90,11 +90,11 @@ An external URL, along with an optional description and deadline for resources s
 ```xml
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <ns2:externalLink xmlns:ns2="http://api.digipost.no/schema/datatypes">
-    <uuid>febab962-77c5-47dd-a679-4f8d9f6f231b</uuid>
-    <url>https://www.digipost.no</url>
-    <deadline>2017-09-09T13:37:00+02:00</deadline>
-    <description>Lenke til vår hovedside.</description>
-    <button-text>Gå til Digipost</button-text>
+    <uuid>ee7018db-155f-456f-aac9-301a3c0092b5</uuid>
+    <url>https://www.oslo.kommune.no/barnehage/svar-pa-tilbud-om-plass/</url>
+    <deadline>2017-09-30T13:37:00+02:00</deadline>
+    <description>Oslo Kommune ber deg akseptere eller avslå tilbudet om barnehageplass.</description>
+    <button-text>Svar på barnehageplass</button-text>
     <url-is-active>true</url-is-active>
     <expired>false</expired>
 </ns2:externalLink>

--- a/readme.md
+++ b/readme.md
@@ -4,6 +4,7 @@
 |----|-----------|
 |[Appointment](#appointment)|Appointment represents a meeting set for a specific place and time|
 |[Category](#category)|Category is a way to specify which category the data of a document is related to.|
+|[ExternalLink](#externallink)|An external URL, along with an optional description and deadline for resources such as a survey.|
 |[Residence](#residence)|Residence is a way of linking separate data for the same residence|
 
 ## Appointment
@@ -69,6 +70,36 @@ Category is a way to specify which category the data of a document is related to
 <ns2:category xmlns:ns2="http://api.digipost.no/schema/datatypes">RESIDENCE</ns2:category>
 ```
 
+## ExternalLink
+
+An external URL, along with an optional description and deadline for resources such as a survey.
+
+### Fields
+
+|Name|Type|Required|Description|
+|----|----|--------|-----------|
+|uuid|String|yes||
+|url|String|yes||
+|deadline|ZonedDateTime|no|ISO8601 full DateTime. After the deadline, the button with the external url will be deactivated.|
+|description|String|no|A short, optional text-field, describing the external url.|
+|buttonText|String|no|The text which will be displayed on the button which links the user to the url-field.|
+|urlIsActive|Boolean|no|A status indicating whether the button and URL will be available to the user or not.|
+
+### XML
+
+```xml
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ns2:externalLink xmlns:ns2="http://api.digipost.no/schema/datatypes">
+    <uuid>febab962-77c5-47dd-a679-4f8d9f6f231b</uuid>
+    <url>https://www.digipost.no</url>
+    <deadline>2017-09-09T13:37:00+02:00</deadline>
+    <description>Lenke til vår hovedside.</description>
+    <button-text>Gå til Digipost</button-text>
+    <url-is-active>true</url-is-active>
+    <expired>false</expired>
+</ns2:externalLink>
+```
+
 ## Residence
 
 Residence is a way of linking separate data for the same residence
@@ -90,9 +121,7 @@ Residence is a way of linking separate data for the same residence
 |houseNumber|String|no|A house number with or without a house letter. E.g. 11 or 11A|
 |streetName|String|yes|The name of the street. E.g. Storgata|
 |postalCode|String|yes||
-|city|String|yes||
-
-### Matrikkel
+|city|String|yes||### Matrikkel
 
 |Name|Type|Required|Description|
 |----|----|--------|-----------|

--- a/readme.md
+++ b/readme.md
@@ -89,15 +89,15 @@ An external URL, along with an optional description and deadline for resources s
 
 ```xml
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ns2:externalLink xmlns:ns2="http://api.digipost.no/schema/datatypes">
-    <uuid>ee7018db-155f-456f-aac9-301a3c0092b5</uuid>
+<externalLink xmlns="http://api.digipost.no/schema/datatypes">
+    <uuid>e408313a-1a77-43af-85cf-f0548c8a1d0f</uuid>
     <url>https://www.oslo.kommune.no/barnehage/svar-pa-tilbud-om-plass/</url>
     <deadline>2017-09-30T13:37:00+02:00</deadline>
     <description>Oslo Kommune ber deg akseptere eller avslå tilbudet om barnehageplass.</description>
     <button-text>Svar på barnehageplass</button-text>
     <url-is-active>true</url-is-active>
-    <expired>false</expired>
-</ns2:externalLink>
+    <expired>true</expired>
+</externalLink>
 ```
 
 ## Residence
@@ -121,7 +121,9 @@ Residence is a way of linking separate data for the same residence
 |houseNumber|String|no|A house number with or without a house letter. E.g. 11 or 11A|
 |streetName|String|yes|The name of the street. E.g. Storgata|
 |postalCode|String|yes||
-|city|String|yes||### Matrikkel
+|city|String|yes||
+
+### Matrikkel
 
 |Name|Type|Required|Description|
 |----|----|--------|-----------|

--- a/src/main/java/no/digipost/api/datatypes/DataTypeIdentifier.java
+++ b/src/main/java/no/digipost/api/datatypes/DataTypeIdentifier.java
@@ -2,6 +2,7 @@ package no.digipost.api.datatypes;
 
 import no.digipost.api.datatypes.types.Appointment;
 import no.digipost.api.datatypes.types.Category;
+import no.digipost.api.datatypes.types.ExternalLink;
 import no.digipost.api.datatypes.types.Residence;
 
 import java.util.Map;
@@ -24,7 +25,8 @@ import static java.util.stream.Collectors.toMap;
 public enum DataTypeIdentifier {
     APPOINTMENT(Appointment.class, "APPT", Appointment.EXAMPLE),
     RESIDENCE(Residence.class, "RESD", Residence.EXAMPLE),
-    CATEGORY(Category.class, "CAT", Category.EXAMPLE);
+    CATEGORY(Category.class, "CAT", Category.EXAMPLE),
+    EXTERNAL_URL(ExternalLink.class, "EXTL", ExternalLink.EXAMPLE);
 
     private final Class<? extends DataType> dataType;
     private final String shortName;

--- a/src/main/java/no/digipost/api/datatypes/DataTypeIdentifier.java
+++ b/src/main/java/no/digipost/api/datatypes/DataTypeIdentifier.java
@@ -26,7 +26,7 @@ public enum DataTypeIdentifier {
     APPOINTMENT(Appointment.class, "APPT", Appointment.EXAMPLE),
     RESIDENCE(Residence.class, "RESD", Residence.EXAMPLE),
     CATEGORY(Category.class, "CAT", Category.EXAMPLE),
-    EXTERNAL_URL(ExternalLink.class, "EXTL", ExternalLink.EXAMPLE);
+    EXTERNAL_LINK(ExternalLink.class, "EXTL", ExternalLink.EXAMPLE);
 
     private final Class<? extends DataType> dataType;
     private final String shortName;

--- a/src/main/java/no/digipost/api/datatypes/types/ExternalLink.java
+++ b/src/main/java/no/digipost/api/datatypes/types/ExternalLink.java
@@ -53,7 +53,7 @@ public class ExternalLink implements DataType {
         return this.deadline != null && this.deadline.isBefore(ZonedDateTime.now());
     }
 
-    public static ExternalLink EXAMPLE = new ExternalLink(UUID.randomUUID().toString(), "https://www.digipost.no",
-            ZonedDateTime.of(2017, 9, 9, 13, 37, 0, 0, ZoneId.systemDefault()),
-            "Lenke til vår hovedside.", "Gå til Digipost", Boolean.TRUE);
+    public static ExternalLink EXAMPLE = new ExternalLink(UUID.randomUUID().toString(), "https://www.oslo.kommune.no/barnehage/svar-pa-tilbud-om-plass/",
+            ZonedDateTime.of(2017, 9, 30, 13, 37, 0, 0, ZoneId.systemDefault()),
+            "Oslo Kommune ber deg akseptere eller avslå tilbudet om barnehageplass.", "Svar på barnehageplass", Boolean.TRUE);
 }

--- a/src/main/java/no/digipost/api/datatypes/types/ExternalLink.java
+++ b/src/main/java/no/digipost/api/datatypes/types/ExternalLink.java
@@ -8,7 +8,6 @@ import no.digipost.api.datatypes.DataType;
 import no.digipost.api.datatypes.documentation.Description;
 
 import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
@@ -24,8 +23,7 @@ public class ExternalLink implements DataType {
 
     @XmlElement
     @NotNull
-    @Description("Target URL of this link. Must be https://")
-    @Pattern(regexp = "^https://.*")
+    @Description("Target URL of this link.")
     String url;
 
     @XmlElement

--- a/src/main/java/no/digipost/api/datatypes/types/ExternalLink.java
+++ b/src/main/java/no/digipost/api/datatypes/types/ExternalLink.java
@@ -24,10 +24,6 @@ public class ExternalLink implements DataType {
 
     @XmlElement
     @NotNull
-    String uuid;
-
-    @XmlElement
-    @NotNull
     String url;
 
     @XmlElement
@@ -44,16 +40,13 @@ public class ExternalLink implements DataType {
     @Description("The text which will be displayed on the button which links the user to the url-field.")
     String buttonText;
 
-    @XmlElement(name = "url-is-active")
-    @Description("A status indicating whether the button and URL will be available to the user or not.")
-    Boolean urlIsActive;
-
     @XmlElement
-    public boolean isExpired() {
-        return this.deadline != null && this.deadline.isBefore(ZonedDateTime.now());
-    }
+    @Size(max = 70)
+    @Description("Optional reference to a customer or case in the sender's system")
+    String sendersReference;
 
-    public static ExternalLink EXAMPLE = new ExternalLink(UUID.randomUUID().toString(), "https://www.oslo.kommune.no/barnehage/svar-pa-tilbud-om-plass/",
+    public static ExternalLink EXAMPLE = new ExternalLink("https://www.oslo.kommune.no/barnehage/svar-pa-tilbud-om-plass/",
             ZonedDateTime.of(2017, 9, 30, 13, 37, 0, 0, ZoneId.systemDefault()),
-            "Oslo Kommune ber deg akseptere eller avslå tilbudet om barnehageplass.", "Svar på barnehageplass", Boolean.TRUE);
+            "Oslo Kommune ber deg akseptere eller avslå tilbudet om barnehageplass.", "Svar på barnehageplass",
+            UUID.randomUUID().toString());
 }

--- a/src/main/java/no/digipost/api/datatypes/types/ExternalLink.java
+++ b/src/main/java/no/digipost/api/datatypes/types/ExternalLink.java
@@ -8,12 +8,12 @@ import no.digipost.api.datatypes.DataType;
 import no.digipost.api.datatypes.documentation.Description;
 
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.util.UUID;
 
 @XmlRootElement
 @Value
@@ -24,6 +24,8 @@ public class ExternalLink implements DataType {
 
     @XmlElement
     @NotNull
+    @Description("Target URL of this link. Must be https://")
+    @Pattern(regexp = "^https://.*")
     String url;
 
     @XmlElement
@@ -48,5 +50,5 @@ public class ExternalLink implements DataType {
     public static ExternalLink EXAMPLE = new ExternalLink("https://www.oslo.kommune.no/barnehage/svar-pa-tilbud-om-plass/",
             ZonedDateTime.of(2017, 9, 30, 13, 37, 0, 0, ZoneId.systemDefault()),
             "Oslo Kommune ber deg akseptere eller avslå tilbudet om barnehageplass.", "Svar på barnehageplass",
-            UUID.randomUUID().toString());
+            "ee50447d-11ca-46bf-bb33-d6edf0e8aef7");
 }

--- a/src/main/java/no/digipost/api/datatypes/types/ExternalLink.java
+++ b/src/main/java/no/digipost/api/datatypes/types/ExternalLink.java
@@ -1,0 +1,59 @@
+package no.digipost.api.datatypes.types;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.Value;
+import no.digipost.api.datatypes.DataType;
+import no.digipost.api.datatypes.documentation.Description;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.UUID;
+
+@XmlRootElement
+@Value
+@AllArgsConstructor
+@NoArgsConstructor(force = true, access = AccessLevel.PRIVATE)
+@Description("An external URL, along with an optional description and deadline for resources such as a survey.")
+public class ExternalLink implements DataType {
+
+    @XmlElement
+    @NotNull
+    String uuid;
+
+    @XmlElement
+    @NotNull
+    String url;
+
+    @XmlElement
+    @Description("ISO8601 full DateTime. After the deadline, the button with the external url will be deactivated.")
+    ZonedDateTime deadline;
+
+    @XmlElement
+    @Size(max = 70)
+    @Description("A short, optional text-field, describing the external url.")
+    String description;
+
+    @XmlElement(name = "button-text")
+    @Size(max = 30)
+    @Description("The text which will be displayed on the button which links the user to the url-field.")
+    String buttonText;
+
+    @XmlElement(name = "url-is-active")
+    @Description("A status indicating whether the button and URL will be available to the user or not.")
+    Boolean urlIsActive;
+
+    @XmlElement
+    public boolean isExpired() {
+        return this.deadline != null && this.deadline.isBefore(ZonedDateTime.now());
+    }
+
+    public static ExternalLink EXAMPLE = new ExternalLink(UUID.randomUUID().toString(), "https://www.digipost.no",
+            ZonedDateTime.of(2017, 9, 9, 13, 37, 0, 0, ZoneId.systemDefault()),
+            "Lenke til vår hovedside.", "Gå til Digipost", Boolean.TRUE);
+}

--- a/src/main/java/no/digipost/api/datatypes/types/ExternalLink.java
+++ b/src/main/java/no/digipost/api/datatypes/types/ExternalLink.java
@@ -42,13 +42,7 @@ public class ExternalLink implements DataType {
     @Description("The text which will be displayed on the button which links the user to the url-field.")
     String buttonText;
 
-    @XmlElement
-    @Size(max = 70)
-    @Description("Optional reference to a customer or case in the sender's system")
-    String sendersReference;
-
     public static ExternalLink EXAMPLE = new ExternalLink("https://www.oslo.kommune.no/barnehage/svar-pa-tilbud-om-plass/",
             ZonedDateTime.of(2017, 9, 30, 13, 37, 0, 0, ZoneId.systemDefault()),
-            "Oslo Kommune ber deg akseptere eller avslå tilbudet om barnehageplass.", "Svar på barnehageplass",
-            "ee50447d-11ca-46bf-bb33-d6edf0e8aef7");
+            "Oslo Kommune ber deg akseptere eller avslå tilbudet om barnehageplass.", "Svar på barnehageplass");
 }

--- a/src/main/java/no/digipost/api/datatypes/types/ExternalLink.java
+++ b/src/main/java/no/digipost/api/datatypes/types/ExternalLink.java
@@ -4,6 +4,7 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import lombok.Value;
+import lombok.experimental.Wither;
 import no.digipost.api.datatypes.DataType;
 import no.digipost.api.datatypes.documentation.Description;
 
@@ -16,6 +17,7 @@ import java.time.ZonedDateTime;
 
 @XmlRootElement
 @Value
+@Wither
 @AllArgsConstructor
 @NoArgsConstructor(force = true, access = AccessLevel.PRIVATE)
 @Description("An external URL, along with an optional description and deadline for resources such as a survey.")

--- a/src/main/resources/no/digipost/api/datatypes/types/jaxb.index
+++ b/src/main/resources/no/digipost/api/datatypes/types/jaxb.index
@@ -1,3 +1,4 @@
 Appointment
 Residence
 Category
+ExternalLink

--- a/src/test/java/no/digipost/api/datatypes/validation/DataTypesValidatorTest.java
+++ b/src/test/java/no/digipost/api/datatypes/validation/DataTypesValidatorTest.java
@@ -1,5 +1,7 @@
 package no.digipost.api.datatypes.validation;
 
+import no.digipost.api.datatypes.DataType;
+import no.digipost.api.datatypes.DataTypeIdentifier;
 import no.digipost.api.datatypes.types.Appointment;
 import no.digipost.api.datatypes.types.AppointmentAddress;
 import org.hamcrest.Matchers;
@@ -11,7 +13,9 @@ import java.util.stream.Stream;
 
 import static co.unruly.matchers.Java8Matchers.where;
 import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
@@ -57,5 +61,14 @@ public class DataTypesValidatorTest {
     @Test
     public void testSuccessfulValidation() {
         validator.validateOrThrow(Appointment.EXAMPLE, __ -> new RuntimeException("Skulle ikke feilet"));
+    }
+
+    @Test
+    public void testValidationOfAllExamples() {
+        final Stream<DataTypesValidationError<DataType>> results =
+                Stream.of(DataTypeIdentifier.values())
+                        .map(DataTypeIdentifier::getExample)
+                        .flatMap(validator::validate);
+        assertThat(results.collect(toList()), is(empty()));
     }
 }


### PR DESCRIPTION
Datatype to support basic 2-way communication. The sender provides a url that will be presented as an answer button together with the message.

An `ExternalLink` type consists of:

* url: Required and must be `https://`
* deadline: Optional deadline after which the link button will be disabled
* description: Optional short description
* buttonText: Optional button text
* sendersReference: Optional reference to a customer or case in the sender's system