### PR TITLE
Mechanism for default values

### DIFF
--- a/src/main/java/no/digipost/api/datatypes/DataType.java
+++ b/src/main/java/no/digipost/api/datatypes/DataType.java
@@ -14,4 +14,8 @@ public interface DataType {
     default DataTypeIdentifier getTypeIdentifier() {
         return DataTypeIdentifier.fromRepresentationType(getClass());
     }
+
+    default DataType withDefaultValues() {
+        return this;
+    }
 }

--- a/src/main/java/no/digipost/api/datatypes/DataType.java
+++ b/src/main/java/no/digipost/api/datatypes/DataType.java
@@ -15,7 +15,7 @@ public interface DataType {
         return DataTypeIdentifier.fromRepresentationType(getClass());
     }
 
-    default DataType withDefaultValues() {
+    default DataType withDefaultsForMissingOptionalValues() {
         return this;
     }
 }

--- a/src/main/java/no/digipost/api/datatypes/types/Appointment.java
+++ b/src/main/java/no/digipost/api/datatypes/types/Appointment.java
@@ -62,7 +62,7 @@ public class Appointment implements DataType {
     List<Info> info;
 
     @Override
-    public DataType withDefaultsForMissingOptionalValues() {
+    public Appointment withDefaultsForMissingOptionalValues() {
         return endTime == null ? this.withEndTime(startTime.plusMinutes(30)) : this;
     }
 

--- a/src/main/java/no/digipost/api/datatypes/types/Appointment.java
+++ b/src/main/java/no/digipost/api/datatypes/types/Appointment.java
@@ -61,6 +61,11 @@ public class Appointment implements DataType {
     @Description("Additional sections of information (max 2) with a title and text")
     List<Info> info;
 
+    @Override
+    public DataType withDefaultValues() {
+        return this.withEndTime(endTime == null ? startTime.plusMinutes(30) : endTime);
+    }
+
     public static Appointment EXAMPLE = new Appointment(
         ZonedDateTime.of(2017, 6, 27, 10, 0, 0, 0, ZoneId.systemDefault()),
             ZonedDateTime.of(2017, 6, 27, 11, 0, 0, 0, ZoneId.systemDefault()),

--- a/src/main/java/no/digipost/api/datatypes/types/Appointment.java
+++ b/src/main/java/no/digipost/api/datatypes/types/Appointment.java
@@ -62,8 +62,8 @@ public class Appointment implements DataType {
     List<Info> info;
 
     @Override
-    public DataType withDefaultValues() {
-        return this.withEndTime(endTime == null ? startTime.plusMinutes(30) : endTime);
+    public DataType withDefaultsForMissingOptionalValues() {
+        return endTime == null ? this.withEndTime(startTime.plusMinutes(30)) : this;
     }
 
     public static Appointment EXAMPLE = new Appointment(


### PR DESCRIPTION
Vi trenger å kunne angi defaultverdier ved mottak av metadata. F.eks. for innkalling sier vi i dokumentasjonen at en time varer default 30 min hvis ikke annet er angitt, men vi gjør ikke noe med det backend 😄 

Denne løsningen vil være såpass generell at vi i backend kun trenger å gjøre noe sånt som dette ved mottak av meldinger `document.getOptionalDataType().map(DataType::withDefaultsForMissingOptionalValues)`