### PR TITLE
Fjerner makslengde på kjøper, selger og pant-type

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <artifactId>digipost-data-types</artifactId>
-    <version>0.11-SNAPSHOT</version>
+    <version>0.11</version>
     <name>${project.artifactId}</name>
     <description>Data types for Digipost Messages</description>
 
@@ -229,6 +229,6 @@
         <connection>scm:git:git@github.com:digipost/digipost-data-types.git</connection>
         <developerConnection>scm:git:git@github.com:digipost/digipost-data-types.git</developerConnection>
         <url>scm:git:git@github.com:digipost/digipost-data-types</url>
-        <tag>HEAD</tag>
+        <tag>0.11</tag>
     </scm>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <artifactId>digipost-data-types</artifactId>
-    <version>0.11</version>
+    <version>0.12-SNAPSHOT</version>
     <name>${project.artifactId}</name>
     <description>Data types for Digipost Messages</description>
 
@@ -229,6 +229,6 @@
         <connection>scm:git:git@github.com:digipost/digipost-data-types.git</connection>
         <developerConnection>scm:git:git@github.com:digipost/digipost-data-types.git</developerConnection>
         <url>scm:git:git@github.com:digipost/digipost-data-types</url>
-        <tag>0.11</tag>
+        <tag>HEAD</tag>
     </scm>
 </project>

--- a/src/main/java/no/digipost/api/datatypes/types/Heftelse.java
+++ b/src/main/java/no/digipost/api/datatypes/types/Heftelse.java
@@ -25,7 +25,6 @@ public class Heftelse {
 
     @XmlElement(name = "type-pant")
     @NotNull
-    @Size(max = 20)
     String typePant;
 
     @XmlElement

--- a/src/main/java/no/digipost/api/datatypes/types/Omsetningshistorikk.java
+++ b/src/main/java/no/digipost/api/datatypes/types/Omsetningshistorikk.java
@@ -32,11 +32,9 @@ public class Omsetningshistorikk {
     String beskrivelse;
 
     @XmlElement
-    @Size(max = 50)
     String selger;
 
     @XmlElement
-    @Size(max = 50)
     String kjoeper;
 
     @XmlElement


### PR DESCRIPTION
I APIet til boligmappa er det ofte lange og/eller mange navn som over-
skrider grensen på 50 tegn. Det finnes også pant-typer som er lenger
enn 20 tegn, f.eks. `PANTSETTELSESERKLÆRING`.