### PR TITLE
Gjør at vi lager en xml fil med datatypes eksemplene.

### DIFF
--- a/datatypes-examples.xml
+++ b/datatypes-examples.xml
@@ -1,5 +1,5 @@
-<datatypes>
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<datatypes>
 <appointment xmlns="http://api.digipost.no/schema/datatypes">
     <start-time>2017-06-27T10:00:00+02:00</start-time>
     <end-time>2017-06-27T11:00:00+02:00</end-time>
@@ -18,7 +18,6 @@
     </info>
 </appointment>
 
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <boligdetaljer xmlns="http://api.digipost.no/schema/datatypes">
     <residence>
         <address>
@@ -66,7 +65,6 @@
     </callToAction>
 </boligdetaljer>
 
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <event xmlns="http://api.digipost.no/schema/datatypes">
     <sub-title>Kommunestyre- og fylkestingvalg</sub-title>
     <start-time>
@@ -100,7 +98,6 @@
     </links>
 </event>
 
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <externalLink xmlns="http://api.digipost.no/schema/datatypes">
     <url>https://www.oslo.kommune.no/barnehage/svar-pa-tilbud-om-plass/</url>
     <deadline>2017-09-30T13:37:00+02:00</deadline>
@@ -108,10 +105,8 @@
     <button-text>Svar på barnehageplass</button-text>
 </externalLink>
 
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <payslip xmlns="http://api.digipost.no/schema/datatypes"/>
 
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <pickup-notice xmlns="http://api.digipost.no/schema/datatypes">
     <parcel-id>KB432788293NO</parcel-id>
     <parcel-uuid>70300492517312675</parcel-uuid>
@@ -176,13 +171,11 @@
     <tags>POSTEN</tags>
 </pickup-notice>
 
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <pickup-notice-status xmlns="http://api.digipost.no/schema/datatypes">
     <status>READY_FOR_PICKUP</status>
     <occurrence-datetime>2019-01-10T10:10:00+01:00</occurrence-datetime>
 </pickup-notice-status>
 
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <proof xmlns="http://api.digipost.no/schema/datatypes">
     <authorizer-name>Bekkestua Bibliotek</authorizer-name>
     <background-color>#e1e1e1</background-color>
@@ -227,7 +220,6 @@
     </info>
 </proof>
 
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <receipt xmlns="http://api.digipost.no/schema/datatypes">
     <receiptId>F96B6805-2453-478A-B58B-CCDFA07E21ED</receiptId>
     <receiptNumber>364567</receiptNumber>
@@ -328,7 +320,6 @@
     <comment>Hip Coffee to the good citizens of Løkka</comment>
 </receipt>
 
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <residence xmlns="http://api.digipost.no/schema/datatypes">
     <address>
         <house-number>23</house-number>
@@ -347,7 +338,6 @@
     <external-id>externalId</external-id>
 </residence>
 
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <signedDocument xmlns="http://api.digipost.no/schema/datatypes">
     <document-issuer>Bedrift AS</document-issuer>
     <document-subject>Ansettelseskontrakt</document-subject>

--- a/datatypes-examples.xml
+++ b/datatypes-examples.xml
@@ -1,0 +1,357 @@
+<datatypes>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<appointment xmlns="http://api.digipost.no/schema/datatypes">
+    <start-time>2017-06-27T10:00:00+02:00</start-time>
+    <end-time>2017-06-27T11:00:00+02:00</end-time>
+    <arrival-time>Oppmøte senest 15 minutter før timen</arrival-time>
+    <place>Oslo City Røntgen</place>
+    <address>
+        <street-address>Storgata 23</street-address>
+        <postal-code>0011</postal-code>
+        <city>Oslo</city>
+        <country>Norge</country>
+    </address>
+    <sub-title>Undersøke smerter i ryggen</sub-title>
+    <info>
+        <title>Informasjon om Oslo City Røntgen</title>
+        <text>Oslo City Røntgen er et spesialistsenter for avansert bildediagnostikk.</text>
+    </info>
+</appointment>
+
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<boligdetaljer xmlns="http://api.digipost.no/schema/datatypes">
+    <residence>
+        <address>
+            <house-number>23</house-number>
+            <street-name>Storgata</street-name>
+            <postal-code>0011</postal-code>
+            <city>Oslo</city>
+        </address>
+        <matrikkel>
+            <kommunenummer>0301</kommunenummer>
+            <gaardsnummer>208</gaardsnummer>
+            <bruksnummer>630</bruksnummer>
+            <festenummer>0</festenummer>
+            <seksjonsnummer>0</seksjonsnummer>
+        </matrikkel>
+        <source>boligmappa</source>
+        <external-id>externalId</external-id>
+    </residence>
+    <hjemmelshavere>
+        <name>Gunnar Gunnersen</name>
+        <email>gunnargunnar@gunn.ar</email>
+    </hjemmelshavere>
+    <bruksareal>59</bruksareal>
+    <antall-oppholdsrom>3</antall-oppholdsrom>
+    <antall-baderom>4</antall-baderom>
+    <omsetningshistorikk>
+        <dato>2017-07-27T10:00:00+02:00</dato>
+        <beskrivelse>Privat salg av sekundærbolig</beskrivelse>
+        <selger>Bill Isalg</selger>
+        <kjoeper>Cooper Coopersen</kjoeper>
+        <beloep>12345678</beloep>
+    </omsetningshistorikk>
+    <organisasjonsnummer>123456789</organisasjonsnummer>
+    <bruksenhet>H1337</bruksenhet>
+    <andelsnummer>42</andelsnummer>
+    <heftelser>
+        <panthaver>TNT ASA</panthaver>
+        <type-pant>Pantedokument</type-pant>
+        <beloep>3000000000</beloep>
+    </heftelser>
+    <callToAction>
+        <url>https://www.example.com</url>
+        <description>Gå til avsenders side for å gjøre en handling</description>
+        <button-text>Ta meg til handling!</button-text>
+    </callToAction>
+</boligdetaljer>
+
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<event xmlns="http://api.digipost.no/schema/datatypes">
+    <sub-title>Kommunestyre- og fylkestingvalg</sub-title>
+    <start-time>
+        <start-time>2019-05-23T10:00:00+02:00</start-time>
+        <end-time>2019-05-23T16:00:00+02:00</end-time>
+    </start-time>
+    <timeLabel>Opening hours</timeLabel>
+    <description>Velkommen til valg! Husk legitimasjon.</description>
+    <place>Sagene skole</place>
+    <placeLabel>Election venue</placeLabel>
+    <address>
+        <street-address>Storgata 23</street-address>
+        <postal-code>0011</postal-code>
+        <city>Oslo</city>
+        <country>Norge</country>
+    </address>
+    <info>
+        <title>Forhåndsstemming</title>
+        <text>Du kan forhåndsstemme fra 10. august</text>
+    </info>
+    <barcodeLabel>Barcode for use on election day:</barcodeLabel>
+    <barcode>
+        <barcode-value>1234567890</barcode-value>
+        <barcode-type>code-128</barcode-type>
+        <barcode-text>Show barcode for faster identification</barcode-text>
+        <show-value-in-barcode>true</show-value-in-barcode>
+    </barcode>
+    <links>
+        <url>https://valg.no</url>
+        <description>Les mer om valget på valg.no</description>
+    </links>
+</event>
+
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<externalLink xmlns="http://api.digipost.no/schema/datatypes">
+    <url>https://www.oslo.kommune.no/barnehage/svar-pa-tilbud-om-plass/</url>
+    <deadline>2017-09-30T13:37:00+02:00</deadline>
+    <description>Oslo Kommune ber deg akseptere eller avslå tilbudet om barnehageplass.</description>
+    <button-text>Svar på barnehageplass</button-text>
+</externalLink>
+
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<payslip xmlns="http://api.digipost.no/schema/datatypes"/>
+
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<pickup-notice xmlns="http://api.digipost.no/schema/datatypes">
+    <parcel-id>KB432788293NO</parcel-id>
+    <parcel-uuid>70300492517312675</parcel-uuid>
+    <barcode>
+        <barcode-value>1234567890</barcode-value>
+        <barcode-type>CODE_128</barcode-type>
+        <barcode-text>Show barcode for faster identification</barcode-text>
+        <show-value-in-barcode>true</show-value-in-barcode>
+    </barcode>
+    <product-name>Klimanøytral Servicepakke</product-name>
+    <arrival-date-time>2018-09-10T10:00:00+02:00</arrival-date-time>
+    <return-date-time>2018-09-24T10:00:00+02:00</return-date-time>
+    <recipient>
+        <name>Test Testesen</name>
+        <digipost-address>test.testesen#0000</digipost-address>
+        <address>
+            <street-address>Storgata 23</street-address>
+            <postal-code>0011</postal-code>
+            <city>Oslo</city>
+            <country>Norge</country>
+        </address>
+    </recipient>
+    <sender>
+        <name>Avsenderservice as</name>
+        <reference>13372500</reference>
+        <address>
+            <street-address>Storgata 23</street-address>
+            <postal-code>0011</postal-code>
+            <city>Oslo</city>
+            <country>Norge</country>
+        </address>
+    </sender>
+    <pickup-place>
+        <name>Coop Mega</name>
+        <code>RC89</code>
+        <instruction>Må hentes innen 010180</instruction>
+        <shelf-location>H32</shelf-location>
+        <address>
+            <street-address>Storgata 23</street-address>
+            <postal-code>0011</postal-code>
+            <city>Oslo</city>
+            <country>Norge</country>
+        </address>
+    </pickup-place>
+    <package>
+        <length>120</length>
+        <width>60</width>
+        <height>60</height>
+        <weight>35000</weight>
+    </package>
+    <cost>
+        <value-to-be-payed>128.00</value-to-be-payed>
+        <package-value>1277.00</package-value>
+        <customs-fee-outlayed>162.00</customs-fee-outlayed>
+        <vas-text>FORENKLET TOLLBEHANDLING</vas-text>
+        <customs-fee>0</customs-fee>
+        <customs-fee-outlay-cost>0</customs-fee-outlay-cost>
+        <cod-amount>0</cod-amount>
+        <cod-fee>0</cod-fee>
+    </cost>
+    <status>READY_FOR_PICKUP</status>
+    <tags>POSTEN</tags>
+</pickup-notice>
+
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<pickup-notice-status xmlns="http://api.digipost.no/schema/datatypes">
+    <status>READY_FOR_PICKUP</status>
+    <occurrence-datetime>2019-01-10T10:10:00+01:00</occurrence-datetime>
+</pickup-notice-status>
+
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<proof xmlns="http://api.digipost.no/schema/datatypes">
+    <authorizer-name>Bekkestua Bibliotek</authorizer-name>
+    <background-color>#e1e1e1</background-color>
+    <issued-time>2019-05-23T10:00:00+02:00</issued-time>
+    <valid-period>
+        <yearly-repeating-period>
+            <start-year>2020</start-year>
+            <end-year>2022</end-year>
+            <from>
+                <month>1</month>
+                <day>1</day>
+            </from>
+            <to>
+                <month>12</month>
+                <day>31</day>
+                <hour>0</hour>
+                <min>0</min>
+                <time-zone>+01:00</time-zone>
+            </to>
+        </yearly-repeating-period>
+    </valid-period>
+    <proof-holder>
+        <firstname>Ola</firstname>
+        <surname>Nordmann</surname>
+        <address>
+            <street-address>Storgata 23</street-address>
+            <postal-code>0011</postal-code>
+            <city>Oslo</city>
+            <country>Norge</country>
+        </address>
+    </proof-holder>
+    <title>Lånekort</title>
+    <proof-id-name>Lånekortnummer</proof-id-name>
+    <proof-id-value>a-132415124-xyzzy-21341</proof-id-value>
+    <attribute>
+        <title>Kaffeklubb</title>
+        <text>Premium deluxe medlem</text>
+    </attribute>
+    <info>
+        <title>Regler</title>
+        <text>Det er ikke lov å rive ut sider i bøkene, eller søle med ketchup. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec aliquet urna condimentum, pulvinar neque ac, tempor tellus. Vestibulum ante ipsum primis in faucibus orci luctus et </text>
+    </info>
+</proof>
+
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<receipt xmlns="http://api.digipost.no/schema/datatypes">
+    <receiptId>F96B6805-2453-478A-B58B-CCDFA07E21ED</receiptId>
+    <receiptNumber>364567</receiptNumber>
+    <purchaseTime>2018-05-27T10:00:00+02:00</purchaseTime>
+    <totalPrice>59.80</totalPrice>
+    <totalVat>11.96</totalVat>
+    <currency>NOK</currency>
+    <cashier>Benny</cashier>
+    <register>15</register>
+    <merchant-chain>7F5A1EFF-ECAE-48A7-A07F-38D87576F815</merchant-chain>
+    <merchant-name>Grünerløkka Hip Coffee</merchant-name>
+    <merchant-phone-number>12345678</merchant-phone-number>
+    <merchant-address>
+        <street-address>Storgata 23</street-address>
+        <postal-code>0011</postal-code>
+        <city>Oslo</city>
+        <country>Norge</country>
+    </merchant-address>
+    <orgnumber>123456789</orgnumber>
+    <barcode>
+        <barcode-value>1234567890</barcode-value>
+        <barcode-type>code-128</barcode-type>
+        <barcode-text>Show barcode for faster identification</barcode-text>
+        <show-value-in-barcode>true</show-value-in-barcode>
+    </barcode>
+    <payments>
+        <type>Bank Axept</type>
+        <card-number>************1234</card-number>
+        <cardName>Visa</cardName>
+        <amount>100.00</amount>
+        <currency-code>NOK</currency-code>
+        <foreign-currency-payment>
+            <currency-code>USD</currency-code>
+            <amount>15</amount>
+            <exchange-rate>7.534567</exchange-rate>
+        </foreign-currency-payment>
+    </payments>
+    <items>
+        <item-name>Tall Cafe latte</item-name>
+        <item-description>Tall vanilla latte with extra sugar</item-description>
+        <item-code>0000012</item-code>
+        <unit>cup</unit>
+        <quantity>2.0</quantity>
+        <item-price>29.90</item-price>
+        <item-vat>5.98</item-vat>
+        <total-price>59.80</total-price>
+        <total-vat>11.96</total-vat>
+        <discount>5.50</discount>
+        <serialNumber>XY12345325GF</serialNumber>
+        <eanCode>1345678</eanCode>
+    </items>
+    <taxiDetails>
+        <carPlateNumber>EK99999</carPlateNumber>
+        <license>12341ASDF</license>
+        <orgNumberLicenseHolder>123456789</orgNumberLicenseHolder>
+        <startTime>2018-06-05T10:00:00+02:00</startTime>
+        <stopTime>2018-06-05T10:30:00+02:00</stopTime>
+        <tips>8.00</tips>
+        <totalMeterPrice>438.50</totalMeterPrice>
+        <totalDistanceBeforeBoardingInMeters>2000</totalDistanceBeforeBoardingInMeters>
+        <totalDistanceInMeters>8500</totalDistanceInMeters>
+        <totalDistanceWithPassengerInMeters>6500</totalDistanceWithPassengerInMeters>
+        <totalTimeBeforeBoardingInSeconds>320</totalTimeBeforeBoardingInSeconds>
+        <totalTimeInSeconds>1220</totalTimeInSeconds>
+        <totalTimeWithPassengerInSeconds>900</totalTimeWithPassengerInSeconds>
+        <vat>
+            <levels>
+                <grossAmount>400.00</grossAmount>
+                <netAmount>320.00</netAmount>
+                <vat>80.00</vat>
+                <vatPercent>25.00</vatPercent>
+            </levels>
+            <sum>64.90</sum>
+        </vat>
+    </taxiDetails>
+    <customer>
+        <name>Ola Nordmann</name>
+        <address>
+            <street-address>Storgata 23</street-address>
+            <postal-code>0011</postal-code>
+            <city>Oslo</city>
+            <country>Norge</country>
+        </address>
+        <phoneNumber>Delivered to the doorstep</phoneNumber>
+    </customer>
+    <delivery>
+        <name>Ola Nordmann</name>
+        <address>
+            <street-address>Storgata 23</street-address>
+            <postal-code>0011</postal-code>
+            <city>Oslo</city>
+            <country>Norge</country>
+        </address>
+        <terms>Delivered to the doorstep</terms>
+    </delivery>
+    <order-number>123456</order-number>
+    <membership-number>HG1234HH8778</membership-number>
+    <comment>Hip Coffee to the good citizens of Løkka</comment>
+</receipt>
+
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<residence xmlns="http://api.digipost.no/schema/datatypes">
+    <address>
+        <house-number>23</house-number>
+        <street-name>Storgata</street-name>
+        <postal-code>0011</postal-code>
+        <city>Oslo</city>
+    </address>
+    <matrikkel>
+        <kommunenummer>0301</kommunenummer>
+        <gaardsnummer>208</gaardsnummer>
+        <bruksnummer>630</bruksnummer>
+        <festenummer>0</festenummer>
+        <seksjonsnummer>0</seksjonsnummer>
+    </matrikkel>
+    <source>boligmappa</source>
+    <external-id>externalId</external-id>
+</residence>
+
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<signedDocument xmlns="http://api.digipost.no/schema/datatypes">
+    <document-issuer>Bedrift AS</document-issuer>
+    <document-subject>Ansettelseskontrakt</document-subject>
+    <signing-time>2018-07-11T10:00:00+02:00</signing-time>
+</signedDocument>
+
+</datatypes>

--- a/pom.xml
+++ b/pom.xml
@@ -298,7 +298,7 @@
                         <phase>package</phase>
                         <configuration>
                             <mainClass>no.digipost.api.datatypes.documentation.DocumentationGenerator</mainClass>
-                            <commandlineArgs>${basedir}/readme.md</commandlineArgs>
+                            <commandlineArgs>${basedir}/readme.md ${basedir}/datatypes-examples.xml</commandlineArgs>
                         </configuration>
                         <goals><goal>java</goal></goals>
                     </execution>

--- a/readme.md
+++ b/readme.md
@@ -43,7 +43,6 @@ Appointment represents a meeting set for a specific place and time
 ### XML
 
 ```xml
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <appointment xmlns="http://api.digipost.no/schema/datatypes">
     <start-time>2017-06-27T10:00:00+02:00</start-time>
     <end-time>2017-06-27T11:00:00+02:00</end-time>
@@ -127,7 +126,6 @@ Details about a Residence, and may be joined with Residence to retrieve the core
 ### XML
 
 ```xml
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <boligdetaljer xmlns="http://api.digipost.no/schema/datatypes">
     <residence>
         <address>
@@ -218,7 +216,6 @@ Event represents an event that occurs over a time period or several days. Eg. a 
 ### XML
 
 ```xml
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <event xmlns="http://api.digipost.no/schema/datatypes">
     <sub-title>Kommunestyre- og fylkestingvalg</sub-title>
     <start-time>
@@ -269,7 +266,6 @@ An external URL, along with an optional description and deadline for resources s
 ### XML
 
 ```xml
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <externalLink xmlns="http://api.digipost.no/schema/datatypes">
     <url>https://www.oslo.kommune.no/barnehage/svar-pa-tilbud-om-plass/</url>
     <deadline>2017-09-30T13:37:00+02:00</deadline>
@@ -291,7 +287,6 @@ For treating documents as Payslips.
 ### XML
 
 ```xml
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <payslip xmlns="http://api.digipost.no/schema/datatypes"/>
 ```
 
@@ -400,7 +395,6 @@ Valid values:
 ### XML
 
 ```xml
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <pickup-notice xmlns="http://api.digipost.no/schema/datatypes">
     <parcel-id>KB432788293NO</parcel-id>
     <parcel-uuid>70300492517312675</parcel-uuid>
@@ -490,7 +484,6 @@ Valid values:
 ### XML
 
 ```xml
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <pickup-notice-status xmlns="http://api.digipost.no/schema/datatypes">
     <status>READY_FOR_PICKUP</status>
     <occurrence-datetime>2019-01-10T10:10:00+01:00</occurrence-datetime>
@@ -571,7 +564,6 @@ Represents a legal document (Certificate, Licence, Permit, etc.) issued to a sin
 ### XML
 
 ```xml
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <proof xmlns="http://api.digipost.no/schema/datatypes">
     <authorizer-name>Bekkestua Bibliotek</authorizer-name>
     <background-color>#e1e1e1</background-color>
@@ -712,7 +704,6 @@ Receipt represents a document containing details about a purchase
 ### XML
 
 ```xml
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <receipt xmlns="http://api.digipost.no/schema/datatypes">
     <receiptId>F96B6805-2453-478A-B58B-CCDFA07E21ED</receiptId>
     <receiptNumber>364567</receiptNumber>
@@ -850,7 +841,6 @@ Residence is a way of linking separate data for the same residence
 ### XML
 
 ```xml
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <residence xmlns="http://api.digipost.no/schema/datatypes">
     <address>
         <house-number>23</house-number>
@@ -885,7 +875,6 @@ Details about a signed document
 ### XML
 
 ```xml
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <signedDocument xmlns="http://api.digipost.no/schema/datatypes">
     <document-issuer>Bedrift AS</document-issuer>
     <document-subject>Ansettelseskontrakt</document-subject>

--- a/src/main/java/no/digipost/api/datatypes/documentation/DocumentationGenerator.java
+++ b/src/main/java/no/digipost/api/datatypes/documentation/DocumentationGenerator.java
@@ -40,8 +40,8 @@ public class DocumentationGenerator {
         Files.write(outputPath, ("<datatypes>" + System.lineSeparator()).getBytes(), StandardOpenOption.APPEND);
 
         for (ComplexType complexType : types.collect(toList())) {
-            final String markdown = new MarkdownPrinter(DataTypesJAXBContext.getSingleton(), false).getXmlExample(complexType.getExample());
-            Files.write(outputPath, markdown.getBytes(StandardCharsets.UTF_8), StandardOpenOption.APPEND);
+            final String xml = new MarkdownPrinter(DataTypesJAXBContext.getSingleton(), false).getXmlExample(complexType.getExample());
+            Files.write(outputPath, xml.getBytes(StandardCharsets.UTF_8), StandardOpenOption.APPEND);
         }
 
         Files.write(outputPath, ("</datatypes>" + System.lineSeparator()).getBytes(), StandardOpenOption.APPEND);

--- a/src/main/java/no/digipost/api/datatypes/documentation/DocumentationGenerator.java
+++ b/src/main/java/no/digipost/api/datatypes/documentation/DocumentationGenerator.java
@@ -7,9 +7,7 @@ import no.digipost.api.datatypes.marshalling.DataTypesJAXBContext;
 import javax.xml.bind.JAXBException;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
+import java.nio.file.*;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -20,7 +18,9 @@ public class DocumentationGenerator {
 
     public static void main(String[] args) throws IOException, JAXBException {
         final Path outputPath = Paths.get(args[0]);
+        final Path examplesOutputPath = Paths.get(args[1]);
         DocumentationGenerator.<DataType>generate(outputPath, DataTypeIdentifier.getAllClasses(), DocumentationGenerator::getDataTypeExample);
+        DocumentationGenerator.<DataType>generateExamples(examplesOutputPath, DataTypeIdentifier.getAllClasses(), DocumentationGenerator::getDataTypeExample);
     }
 
     public static DataType getDataTypeExample(Class<? extends DataType> dataType) {
@@ -31,5 +31,19 @@ public class DocumentationGenerator {
         final Stream<ComplexType> types = DocumentationStructureBuilder.buildTypeStructure(typesToDocument, getExample);
         final String markdown = new MarkdownPrinter(DataTypesJAXBContext.getSingleton(), false).print(types.collect(toList()));
         Files.write(outputPath, markdown.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static <T> void generateExamples(Path outputPath, Set<Class<? extends T>> typesToDocument, Function<Class<? extends T>, T> getExample) throws IOException, JAXBException {
+        final Stream<ComplexType> types = DocumentationStructureBuilder.buildTypeStructure(typesToDocument, getExample);
+
+        Files.write(outputPath, "".getBytes());
+        Files.write(outputPath, ("<datatypes>" + System.lineSeparator()).getBytes(), StandardOpenOption.APPEND);
+
+        for (ComplexType complexType : types.collect(toList())) {
+            final String markdown = new MarkdownPrinter(DataTypesJAXBContext.getSingleton(), false).getXmlExample(complexType.getExample());
+            Files.write(outputPath, markdown.getBytes(StandardCharsets.UTF_8), StandardOpenOption.APPEND);
+        }
+
+        Files.write(outputPath, ("</datatypes>" + System.lineSeparator()).getBytes(), StandardOpenOption.APPEND);
     }
 }

--- a/src/main/java/no/digipost/api/datatypes/documentation/DocumentationGenerator.java
+++ b/src/main/java/no/digipost/api/datatypes/documentation/DocumentationGenerator.java
@@ -37,13 +37,13 @@ public class DocumentationGenerator {
         final Stream<ComplexType> types = DocumentationStructureBuilder.buildTypeStructure(typesToDocument, getExample);
 
         Files.write(outputPath, "".getBytes());
-        Files.write(outputPath, ("<datatypes>" + System.lineSeparator()).getBytes(), StandardOpenOption.APPEND);
+        Files.write(outputPath, ("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" + System.lineSeparator() + "<datatypes>" + System.lineSeparator()).getBytes(), StandardOpenOption.APPEND);
 
         for (ComplexType complexType : types.collect(toList())) {
             final String xml = new MarkdownPrinter(DataTypesJAXBContext.getSingleton(), false).getXmlExample(complexType.getExample());
             Files.write(outputPath, xml.getBytes(StandardCharsets.UTF_8), StandardOpenOption.APPEND);
         }
 
-        Files.write(outputPath, ("</datatypes>" + System.lineSeparator()).getBytes(), StandardOpenOption.APPEND);
+        Files.write(outputPath, "</datatypes>".getBytes(), StandardOpenOption.APPEND);
     }
 }

--- a/src/main/java/no/digipost/api/datatypes/documentation/MarkdownPrinter.java
+++ b/src/main/java/no/digipost/api/datatypes/documentation/MarkdownPrinter.java
@@ -69,25 +69,20 @@ public class MarkdownPrinter {
     }
 
     private String printXmlExample(Object example) {
-        try {
-            final StringWriter writer = new StringWriter();
-            final Marshaller marshaller = jaxb.createMarshaller();
-            marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
-            marshaller.marshal(example, writer);
-            return heading(3, "XML") + LLF +
-                    code("xml", writer.toString().trim());
-        } catch (JAXBException e) {
-            throw new RuntimeException(e);
-        }
+        return heading(3, "XML") + LLF + code("xml", createXmlExample(example).trim());
     }
 
     public String getXmlExample(Object example) {
+        return createXmlExample(example) + LF;
+    }
+
+    private String createXmlExample(Object example) {
         try {
             final StringWriter writer = new StringWriter();
             final Marshaller marshaller = jaxb.createMarshaller();
             marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
             marshaller.marshal(example, writer);
-            return writer.toString() + LF;
+            return writer.toString();
         } catch (JAXBException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/no/digipost/api/datatypes/documentation/MarkdownPrinter.java
+++ b/src/main/java/no/digipost/api/datatypes/documentation/MarkdownPrinter.java
@@ -69,20 +69,17 @@ public class MarkdownPrinter {
     }
 
     private String printXmlExample(Object example) {
-        return heading(3, "XML") + LLF + code("xml", createXmlExample(example).trim());
+        return heading(3, "XML") + LLF + code("xml", getXmlExample(example).trim());
     }
 
     public String getXmlExample(Object example) {
-        return createXmlExample(example) + LF;
-    }
-
-    private String createXmlExample(Object example) {
         try {
             final StringWriter writer = new StringWriter();
             final Marshaller marshaller = jaxb.createMarshaller();
             marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
+            marshaller.setProperty(Marshaller.JAXB_FRAGMENT, Boolean.TRUE);
             marshaller.marshal(example, writer);
-            return writer.toString();
+            return writer.toString() + LLF;
         } catch (JAXBException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/no/digipost/api/datatypes/documentation/MarkdownPrinter.java
+++ b/src/main/java/no/digipost/api/datatypes/documentation/MarkdownPrinter.java
@@ -81,6 +81,18 @@ public class MarkdownPrinter {
         }
     }
 
+    public String getXmlExample(Object example) {
+        try {
+            final StringWriter writer = new StringWriter();
+            final Marshaller marshaller = jaxb.createMarshaller();
+            marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
+            marshaller.marshal(example, writer);
+            return writer.toString() + LF;
+        } catch (JAXBException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     private String code(String type, String s) {
         return "```" + type + LF + s + LF + "```";
     }

--- a/src/test/resources/no/digipost/api/datatypes/documentation/testdoc.md
+++ b/src/test/resources/no/digipost/api/datatypes/documentation/testdoc.md
@@ -39,7 +39,6 @@
 ### XML
 
 ```xml
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <shortTextMessage xmlns="http://api.digipost.no/schema/datatypes">
     <message>Dette er en kort melding til deg</message>
     <metaData>


### PR DESCRIPTION
Dotnet klient biblioteket trenger test data for å verifisere sine genererte klasser. Ettersom klient biblioteket ikke har noe forhold til datatyper annet enn at de er strings med xml, så er det litt vanskelig å "mocke" test data for serialization. Dermed er det lettere å bare eksportere eksemplene herfra til en xml fil vi kan flytte over og bruke.