### PR TITLE
add new datatype inkasso for norwegian debt collection

### DIFF
--- a/datatypes-examples.xml
+++ b/datatypes-examples.xml
@@ -105,6 +105,18 @@
     <button-text>Svar på barnehageplass</button-text>
 </externalLink>
 
+<inkasso xmlns="http://api.digipost.no/schema/datatypes">
+    <link>
+        <url>https://www.example.com</url>
+        <description>Gå til avsenders side for å gjøre en handling</description>
+        <button-text>Ta meg til handling!</button-text>
+    </link>
+    <due-date>2019-12-10T00:00:00+01:00</due-date>
+    <sum>42</sum>
+    <account>012354243209523583</account>
+    <kid>1435025439583420243982723</kid>
+</inkasso>
+
 <payslip xmlns="http://api.digipost.no/schema/datatypes"/>
 
 <pickup-notice xmlns="http://api.digipost.no/schema/datatypes">

--- a/datatypes.xsd
+++ b/datatypes.xsd
@@ -9,6 +9,8 @@
 
   <xs:element name="externalLink" type="tns:externalLink"/>
 
+  <xs:element name="inkasso" type="tns:inkasso"/>
+
   <xs:element name="payslip" type="tns:payslip"/>
 
   <xs:element name="pickup-notice" type="tns:pickupNotice"/>
@@ -176,6 +178,16 @@
       <xs:element minOccurs="0" name="amount" type="xs:decimal"/>
       <xs:element minOccurs="0" name="exchange-rate" type="xs:decimal"/>
       <xs:element minOccurs="0" name="label" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType final="extension restriction" name="inkasso">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="link" type="tns:externalLink"/>
+      <xs:element name="due-date" type="xs:string"/>
+      <xs:element minOccurs="0" name="sum" type="xs:decimal"/>
+      <xs:element minOccurs="0" name="account" type="xs:string"/>
+      <xs:element minOccurs="0" name="kid" type="xs:string"/>
     </xs:sequence>
   </xs:complexType>
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <artifactId>digipost-data-types</artifactId>
-    <version>0.26-SNAPSHOT</version>
+    <version>0.26</version>
     <name>Digipost Data Types</name>
     <description>Data types for Digipost messages</description>
 
@@ -343,6 +343,6 @@
         <connection>scm:git:git@github.com:digipost/digipost-data-types.git</connection>
         <developerConnection>scm:git:git@github.com:digipost/digipost-data-types.git</developerConnection>
         <url>scm:git:git@github.com:digipost/digipost-data-types</url>
-        <tag>HEAD</tag>
+        <tag>0.26</tag>
     </scm>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <artifactId>digipost-data-types</artifactId>
-    <version>0.26</version>
+    <version>0.27-SNAPSHOT</version>
     <name>Digipost Data Types</name>
     <description>Data types for Digipost messages</description>
 
@@ -343,6 +343,6 @@
         <connection>scm:git:git@github.com:digipost/digipost-data-types.git</connection>
         <developerConnection>scm:git:git@github.com:digipost/digipost-data-types.git</developerConnection>
         <url>scm:git:git@github.com:digipost/digipost-data-types</url>
-        <tag>0.26</tag>
+        <tag>HEAD</tag>
     </scm>
 </project>

--- a/readme.md
+++ b/readme.md
@@ -6,6 +6,7 @@
 |[Boligdetaljer](#boligdetaljer)|Details about a Residence, and may be joined with Residence to retrieve the core fields of a Residence.|
 |[Event](#event)|Event represents an event that occurs over a time period or several days. Eg. a conference or an election|
 |[ExternalLink](#externallink)|An external URL, along with an optional description and deadline for resources such as a survey.|
+|[Inkasso](#inkasso)|A debt collection payment|
 |[Payslip](#payslip)|For treating documents as Payslips.|
 |[PickupNotice](#pickupnotice)|Details about a pickup notice|
 |[PickupNoticeStatus](#pickupnoticestatus)|Updates to status for PickupNotice|
@@ -272,6 +273,45 @@ An external URL, along with an optional description and deadline for resources s
     <description>Oslo Kommune ber deg akseptere eller avslå tilbudet om barnehageplass.</description>
     <button-text>Svar på barnehageplass</button-text>
 </externalLink>
+```
+
+## Inkasso
+
+A debt collection payment
+
+### Fields
+
+|Name|Type|Required|Description|
+|----|----|--------|-----------|
+|link|[ExternalLink](#inkassoexternallink)|no|A link to more information, or further actions that can be taken|
+|dueDate|ZonedDateTime|yes|When the payment falls due|
+|sum|BigDecimal|no|The sum to be payed|
+|account|String|no|The creditor account for the payment|
+|kid|String|no|The customer identification number|
+
+### Inkasso.ExternalLink
+
+|Name|Type|Required|Description|
+|----|----|--------|-----------|
+|url|URI|yes|Target URL of this link. Must be http or https.|
+|deadline|ZonedDateTime|no|Optional deadline for the user to respond. ISO8601 full DateTime.|
+|description|String|no|A short, optional text-field, describing the external link.|
+|buttonText|String|no|Optional text which will be displayed on the button.|
+
+### XML
+
+```xml
+<inkasso xmlns="http://api.digipost.no/schema/datatypes">
+    <link>
+        <url>https://www.example.com</url>
+        <description>Gå til avsenders side for å gjøre en handling</description>
+        <button-text>Ta meg til handling!</button-text>
+    </link>
+    <due-date>2019-12-10T00:00:00+01:00</due-date>
+    <sum>42</sum>
+    <account>012354243209523583</account>
+    <kid>1435025439583420243982723</kid>
+</inkasso>
 ```
 
 ## Payslip

--- a/src/main/java/no/digipost/api/datatypes/DataTypeIdentifier.java
+++ b/src/main/java/no/digipost/api/datatypes/DataTypeIdentifier.java
@@ -4,6 +4,7 @@ import no.digipost.api.datatypes.types.Appointment;
 import no.digipost.api.datatypes.types.Boligdetaljer;
 import no.digipost.api.datatypes.types.Event;
 import no.digipost.api.datatypes.types.ExternalLink;
+import no.digipost.api.datatypes.types.Inkasso;
 import no.digipost.api.datatypes.types.Payslip;
 import no.digipost.api.datatypes.types.Residence;
 import no.digipost.api.datatypes.types.SignedDocument;
@@ -44,6 +45,7 @@ public enum DataTypeIdentifier {
     , PICKUP_NOTICE_STATUS(PickupNoticeStatus.class, "PKUS", PickupNoticeStatus.EXAMPLE)
     , EVENT(Event.class, "EVNT", Event.EXAMPLE)
     , PROOF(Proof.class, "PRF", Proof.EXAMPLE)
+    , INKASSO(Inkasso.class, "INKA", Inkasso.EXAMPLE)
     ;
 
     private final Class<? extends DataType> dataType;

--- a/src/main/java/no/digipost/api/datatypes/types/Inkasso.java
+++ b/src/main/java/no/digipost/api/datatypes/types/Inkasso.java
@@ -1,0 +1,44 @@
+package no.digipost.api.datatypes.types;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.Value;
+import lombok.experimental.Wither;
+import no.digipost.api.datatypes.DataType;
+import no.digipost.api.datatypes.documentation.Description;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import java.math.BigDecimal;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+@XmlRootElement
+@Value
+@AllArgsConstructor
+@NoArgsConstructor(force = true, access = AccessLevel.PRIVATE)
+@Wither
+@Description("A debt collection payment")
+public class Inkasso implements DataType {
+    @XmlElement
+    @Description("A link to more information, or further actions that can be taken")
+    ExternalLink link;
+    @XmlElement(required = true, name = "due-date")
+    @Description("When the payment falls due")
+    ZonedDateTime dueDate;
+    @XmlElement
+    @Description("The sum to be payed")
+    BigDecimal sum;
+    @XmlElement
+    @Description("The creditor account for the payment")
+    String account;
+    @XmlElement
+    @Description("The customer identification number")
+    String kid;
+
+    public static Inkasso EXAMPLE = new Inkasso(ExternalLink.EXAMPLE_NO_DEADLINE,
+            ZonedDateTime.of(2019, 12, 10, 0, 0, 0, 0, ZoneId.systemDefault()),
+            BigDecimal.valueOf(42), "012354243209523583", "1435025439583420243982723");
+
+}

--- a/src/main/resources/no/digipost/api/datatypes/types/jaxb.index
+++ b/src/main/resources/no/digipost/api/datatypes/types/jaxb.index
@@ -9,3 +9,4 @@ Payslip
 SignedDocument
 pickup.PickupNotice
 pickup.PickupNoticeStatus
+Inkasso


### PR DESCRIPTION
Velger å kalle den nye datatypen Inkasso fordi:
- engelske "debt collection" er et keitete ord fra en annen rettstradisjon enn den denne datatypen skal brukes innen
- det heter "inkasso" på alle de skandinaviske språkene og tysk osv.