### PR TITLE
Øk maxlengden til et navn for hjemmelshaver.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <artifactId>digipost-data-types</artifactId>
-    <version>0.27</version>
+    <version>0.28-SNAPSHOT</version>
     <name>Digipost Data Types</name>
     <description>Data types for Digipost messages</description>
 
@@ -343,6 +343,6 @@
         <connection>scm:git:git@github.com:digipost/digipost-data-types.git</connection>
         <developerConnection>scm:git:git@github.com:digipost/digipost-data-types.git</developerConnection>
         <url>scm:git:git@github.com:digipost/digipost-data-types</url>
-        <tag>0.27</tag>
+        <tag>HEAD</tag>
     </scm>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <artifactId>digipost-data-types</artifactId>
-    <version>0.27-SNAPSHOT</version>
+    <version>0.27</version>
     <name>Digipost Data Types</name>
     <description>Data types for Digipost messages</description>
 
@@ -343,6 +343,6 @@
         <connection>scm:git:git@github.com:digipost/digipost-data-types.git</connection>
         <developerConnection>scm:git:git@github.com:digipost/digipost-data-types.git</developerConnection>
         <url>scm:git:git@github.com:digipost/digipost-data-types</url>
-        <tag>HEAD</tag>
+        <tag>0.27</tag>
     </scm>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>no.digipost</groupId>
         <artifactId>digipost-open-super-pom</artifactId>
-        <version>3</version>
+        <version>4</version>
     </parent>
 
     <artifactId>digipost-data-types</artifactId>

--- a/src/main/java/no/digipost/api/datatypes/types/Hjemmelshaver.java
+++ b/src/main/java/no/digipost/api/datatypes/types/Hjemmelshaver.java
@@ -5,7 +5,6 @@ import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import lombok.Value;
 
-import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import javax.xml.bind.annotation.XmlElement;
@@ -19,7 +18,7 @@ public class Hjemmelshaver {
 
     @XmlElement
     @NotNull
-    @Size(max = 50)
+    @Size(max = 75)
     String name;
 
     @XmlElement

--- a/src/main/java/no/digipost/api/datatypes/types/ResidenceAddress.java
+++ b/src/main/java/no/digipost/api/datatypes/types/ResidenceAddress.java
@@ -31,7 +31,7 @@ public class ResidenceAddress {
     String unitNumber;
 
     @XmlElement(name = "house-number")
-    @Size(max = 5)
+    @Size(max = 20)
     @Description("A house number with or without a house letter. E.g. 11 or 11A")
     String houseNumber;
 


### PR DESCRIPTION
Noen personer har navn over 50 tegn. Vi øker derfor denne grensen til en (tilsynelatende) fornuftig lengde.