### PR TITLE
Fjern tidssoner fra gyldigheten i Proof

### DIFF
--- a/datatypes-examples.xml
+++ b/datatypes-examples.xml
@@ -209,7 +209,6 @@
                 <day>31</day>
                 <hour>0</hour>
                 <min>0</min>
-                <time-zone>+01:00</time-zone>
             </to>
         </yearly-repeating-period>
     </valid-period>

--- a/readme.md
+++ b/readme.md
@@ -601,8 +601,8 @@ Represents a legal document (Certificate, Licence, Permit, etc.) issued to a sin
 
 |Name|Type|Required|Description|
 |----|----|--------|-----------|
-|from|ZonedDateTime|no|ISO8601 full DateTime|
-|to|ZonedDateTime|no|ISO8601 full DateTime|
+|from|LocalDateTime|no|ISO8601 full DateTime|
+|to|LocalDateTime|no|ISO8601 full DateTime|
 
 ### Proof.YearlyRepeatingPeriod
 
@@ -621,7 +621,7 @@ Represents a legal document (Certificate, Licence, Permit, etc.) issued to a sin
 |day|Integer|yes||
 |hour|Integer|no||
 |min|Integer|no||
-|timeZone|String|no|Timezone ISO-8601|
+|timeZone|String|no|Deprecated, do not use. Will be ignored.|
 
 ### Proof.ProofHolder
 
@@ -670,7 +670,6 @@ Valid values:
                 <day>31</day>
                 <hour>0</hour>
                 <min>0</min>
-                <time-zone>+01:00</time-zone>
             </to>
         </yearly-repeating-period>
     </valid-period>

--- a/src/main/java/no/digipost/api/datatypes/marshalling/DataTypesJsonMapper.java
+++ b/src/main/java/no/digipost/api/datatypes/marshalling/DataTypesJsonMapper.java
@@ -16,7 +16,7 @@ public class DataTypesJsonMapper {
         ObjectMapper mapper = new ObjectMapper();
         mapper.registerModule(new JavaTimeModule());
         mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
-        mapper.setTimeZone(TimeZone.getDefault());
+        mapper.disable(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE);
         mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         mapper.setPropertyNamingStrategy(PropertyNamingStrategy.LOWER_CAMEL_CASE);
         return mapper;

--- a/src/main/java/no/digipost/api/datatypes/marshalling/LocalDateTimeXmlAdapter.java
+++ b/src/main/java/no/digipost/api/datatypes/marshalling/LocalDateTimeXmlAdapter.java
@@ -1,0 +1,24 @@
+package no.digipost.api.datatypes.marshalling;
+
+import javax.xml.bind.annotation.adapters.XmlAdapter;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class LocalDateTimeXmlAdapter extends XmlAdapter<String, LocalDateTime> {
+    @Override
+    public String marshal(LocalDateTime v) {
+        if (v == null) {
+            return null;
+        }
+        return v.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+    }
+
+    @Override
+    public LocalDateTime unmarshal(final String s) {
+        if (s == null) {
+            return null;
+        }
+        return LocalDateTime.from(DateTimeFormatter.ISO_DATE_TIME.parse(s));
+    }
+
+}

--- a/src/main/java/no/digipost/api/datatypes/marshalling/ZonedDateTimeXmlAdapter.java
+++ b/src/main/java/no/digipost/api/datatypes/marshalling/ZonedDateTimeXmlAdapter.java
@@ -2,9 +2,12 @@ package no.digipost.api.datatypes.marshalling;
 
 import javax.xml.bind.DatatypeConverter;
 import javax.xml.bind.annotation.adapters.XmlAdapter;
-import java.time.ZoneId;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoField;
+import java.time.temporal.TemporalAccessor;
 import java.util.GregorianCalendar;
 
 public class ZonedDateTimeXmlAdapter extends XmlAdapter<String, ZonedDateTime> {
@@ -21,7 +24,12 @@ public class ZonedDateTimeXmlAdapter extends XmlAdapter<String, ZonedDateTime> {
         if (s == null) {
             return null;
         }
-        return ZonedDateTime.from(DateTimeFormatter.ISO_DATE_TIME.parse(s)).withZoneSameInstant(ZoneId.systemDefault());
+        final TemporalAccessor parsed = DateTimeFormatter.ISO_DATE_TIME.parse(s);
+        if (parsed.isSupported(ChronoField.OFFSET_SECONDS)) {
+            return ZonedDateTime.from(parsed);
+        } else {
+            return LocalDateTime.from(parsed).atZone(ZoneOffset.UTC);
+        }
     }
 
 }

--- a/src/main/java/no/digipost/api/datatypes/types/Appointment.java
+++ b/src/main/java/no/digipost/api/datatypes/types/Appointment.java
@@ -72,8 +72,8 @@ public class Appointment implements DataType {
     }
 
     public static Appointment EXAMPLE = new Appointment(
-            ZonedDateTime.of(2017, 6, 27, 10, 0, 0, 0, ZoneId.systemDefault())
-            , ZonedDateTime.of(2017, 6, 27, 11, 0, 0, 0, ZoneId.systemDefault())
+            ZonedDateTime.of(2017, 6, 27, 10, 0, 0, 0, ZoneId.of("+02:00"))
+            , ZonedDateTime.of(2017, 6, 27, 11, 0, 0, 0, ZoneId.of("+02:00"))
             , "Oppmøte senest 15 minutter før timen"
             , "Oslo City Røntgen"
             , Address.EXAMPLE

--- a/src/main/java/no/digipost/api/datatypes/types/Boligdetaljer.java
+++ b/src/main/java/no/digipost/api/datatypes/types/Boligdetaljer.java
@@ -94,7 +94,7 @@ public class Boligdetaljer implements DataType {
             Residence.EXAMPLE
             , Collections.singletonList(new Hjemmelshaver("Gunnar Gunnersen", "gunnargunnar@gunn.ar"))
             , 59, 3, 4
-            , Collections.singletonList(new Omsetningshistorikk(ZonedDateTime.of(2017, 7, 27, 10, 0, 0, 0, ZoneId.systemDefault())
+            , Collections.singletonList(new Omsetningshistorikk(ZonedDateTime.of(2017, 7, 27, 10, 0, 0, 0, ZoneId.of("+02:00"))
             , "Privat salg av sekundærbolig"
             , "Bill Isalg"
             , "Cooper Coopersen"

--- a/src/main/java/no/digipost/api/datatypes/types/ExternalLink.java
+++ b/src/main/java/no/digipost/api/datatypes/types/ExternalLink.java
@@ -57,7 +57,7 @@ public class ExternalLink implements DataType {
     String buttonText;
 
     public static ExternalLink EXAMPLE = new ExternalLink(URI.create("https://www.oslo.kommune.no/barnehage/svar-pa-tilbud-om-plass/"),
-            ZonedDateTime.of(2017, 9, 30, 13, 37, 0, 0, ZoneId.systemDefault()),
+            ZonedDateTime.of(2017, 9, 30, 13, 37, 0, 0, ZoneId.of("+02:00")),
             "Oslo Kommune ber deg akseptere eller avslå tilbudet om barnehageplass.", "Svar på barnehageplass");
 
     public static ExternalLink EXAMPLE_NO_DEADLINE = new ExternalLink(URI.create("https://www.example.com"),

--- a/src/main/java/no/digipost/api/datatypes/types/Inkasso.java
+++ b/src/main/java/no/digipost/api/datatypes/types/Inkasso.java
@@ -42,7 +42,7 @@ public class Inkasso implements DataType {
 
     public static Inkasso EXAMPLE = new Inkasso(
             ExternalLink.EXAMPLE_NO_DEADLINE
-            , ZonedDateTime.of(2019, 12, 10, 0, 0, 0, 0, ZoneId.systemDefault())
+            , ZonedDateTime.of(2019, 12, 10, 0, 0, 0, 0, ZoneId.of("+01:00"))
             , BigDecimal.valueOf(42), "01235424320", "1435025439583420243982723"
     );
 

--- a/src/main/java/no/digipost/api/datatypes/types/SignedDocument.java
+++ b/src/main/java/no/digipost/api/datatypes/types/SignedDocument.java
@@ -39,7 +39,7 @@ public class SignedDocument implements DataType {
     public static SignedDocument EXAMPLE = new SignedDocument(
             "Bedrift AS",
             "Ansettelseskontrakt",
-            ZonedDateTime.of(2018, 7, 11, 10, 0, 0, 0, ZoneId.systemDefault())
+            ZonedDateTime.of(2018, 7, 11, 10, 0, 0, 0, ZoneId.of("+02:00"))
     );
 }
 

--- a/src/main/java/no/digipost/api/datatypes/types/TimeInterval.java
+++ b/src/main/java/no/digipost/api/datatypes/types/TimeInterval.java
@@ -30,7 +30,7 @@ public class TimeInterval {
     ZonedDateTime endTime;
 
     public static TimeInterval EXAMPLE = new TimeInterval(
-            ZonedDateTime.of(2019, 5, 23, 10, 0, 0, 0, ZoneId.systemDefault())
-            , ZonedDateTime.of(2019, 5, 23, 16, 0, 0, 0, ZoneId.systemDefault())
+            ZonedDateTime.of(2019, 5, 23, 10, 0, 0, 0, ZoneId.of("+02:00"))
+            , ZonedDateTime.of(2019, 5, 23, 16, 0, 0, 0, ZoneId.of("+02:00"))
     );
 }

--- a/src/main/java/no/digipost/api/datatypes/types/package-info.java
+++ b/src/main/java/no/digipost/api/datatypes/types/package-info.java
@@ -1,15 +1,20 @@
 @XmlSchema(namespace = DIGIPOST_DATATYPES_NAMESPACE, elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
 @XmlAccessorType(XmlAccessType.FIELD)
-@XmlJavaTypeAdapter(ZonedDateTimeXmlAdapter.class)
+@XmlJavaTypeAdapters({
+        @XmlJavaTypeAdapter(ZonedDateTimeXmlAdapter.class),
+        @XmlJavaTypeAdapter(LocalDateTimeXmlAdapter.class)
+})
 @DataTypePackage
 package no.digipost.api.datatypes.types;
 
 import no.digipost.api.datatypes.documentation.DataTypePackage;
+import no.digipost.api.datatypes.marshalling.LocalDateTimeXmlAdapter;
 import no.digipost.api.datatypes.marshalling.ZonedDateTimeXmlAdapter;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlSchema;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapters;
 
 import static no.digipost.api.datatypes.marshalling.DataTypesJAXBContext.DIGIPOST_DATATYPES_NAMESPACE;

--- a/src/main/java/no/digipost/api/datatypes/types/pickup/PickupNotice.java
+++ b/src/main/java/no/digipost/api/datatypes/types/pickup/PickupNotice.java
@@ -111,8 +111,8 @@ public class PickupNotice implements DataType {
             , "70300492517312675"
             , Barcode.EXAMPLE.withBarcodeType("CODE_128")
             , "Klimanøytral Servicepakke"
-            , ZonedDateTime.of(2018, 9, 10, 10, 0, 0, 0, ZoneId.systemDefault())
-            , ZonedDateTime.of(2018, 9, 24, 10, 0, 0, 0, ZoneId.systemDefault())
+            , ZonedDateTime.of(2018, 9, 10, 10, 0, 0, 0, ZoneId.of("+02:00"))
+            , ZonedDateTime.of(2018, 9, 24, 10, 0, 0, 0, ZoneId.of("+02:00"))
             , Recipient.EXAMPLE
             , Sender.EXAMPLE
             , PickupPlace.EXAMPLE

--- a/src/main/java/no/digipost/api/datatypes/types/pickup/PickupNoticeStatus.java
+++ b/src/main/java/no/digipost/api/datatypes/types/pickup/PickupNoticeStatus.java
@@ -37,6 +37,6 @@ public class PickupNoticeStatus implements DataType {
 
     public static PickupNoticeStatus EXAMPLE = new PickupNoticeStatus(
             Status.READY_FOR_PICKUP
-            , ZonedDateTime.of(2019, 1, 10, 10, 10, 0, 0, ZoneId.systemDefault())
+            , ZonedDateTime.of(2019, 1, 10, 10, 10, 0, 0, ZoneId.of("+01:00"))
     );
 }

--- a/src/main/java/no/digipost/api/datatypes/types/proof/CalendarDate.java
+++ b/src/main/java/no/digipost/api/datatypes/types/proof/CalendarDate.java
@@ -1,11 +1,9 @@
 package no.digipost.api.datatypes.types.proof;
 
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import lombok.Value;
 import lombok.With;
-import lombok.experimental.Wither;
 import no.digipost.api.datatypes.documentation.Description;
 
 import javax.validation.constraints.NotNull;
@@ -16,7 +14,6 @@ import javax.xml.bind.annotation.XmlType;
 
 @XmlType
 @Value
-@AllArgsConstructor
 @NoArgsConstructor(force = true, access = AccessLevel.PRIVATE)
 @With
 public class CalendarDate {
@@ -44,8 +41,22 @@ public class CalendarDate {
 
     @XmlElement(name = "time-zone", defaultValue = "+01:00")
     @Pattern(regexp = "Z|[+-][01]\\d:{0,1}[0-5]\\d|[+-][01]\\d")
-    @Description("Timezone ISO-8601")
+    @Description("Deprecated, do not use. Will be ignored.")
     String timeZone;
 
-    public static CalendarDate EXAMPLE = new CalendarDate(5, 9, 0, 0, "+01:00");
+    @Deprecated
+    public CalendarDate(Integer month, Integer day, Integer hour, Integer min, String timeZone) {
+        this.month = month;
+        this.day = day;
+        this.hour = hour;
+        this.min = min;
+        this.timeZone = timeZone;
+    }
+
+    public CalendarDate(Integer month, Integer day, Integer hour, Integer min) {
+        this(month, day, hour, min, null);
+    }
+
+
+    public static CalendarDate EXAMPLE = new CalendarDate(5, 9, 0, 0);
 }

--- a/src/main/java/no/digipost/api/datatypes/types/proof/Period.java
+++ b/src/main/java/no/digipost/api/datatypes/types/proof/Period.java
@@ -1,7 +1,5 @@
 package no.digipost.api.datatypes.types.proof;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
@@ -14,11 +12,6 @@ import no.digipost.api.datatypes.validation.ValidPeriode;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
-import java.time.temporal.ChronoField;
-import java.time.temporal.TemporalAccessor;
 
 @XmlType
 @Value
@@ -35,24 +28,6 @@ public class Period {
     @XmlElement(name = "to")
     @Description("ISO8601 full DateTime")
     LocalDateTime to;
-
-    @Deprecated
-    @JsonCreator
-    public Period(@JsonProperty("from") String from, @JsonProperty("to") String to) {
-        this(localDate(from), localDate(to));
-    }
-
-    private static LocalDateTime localDate(String datetime) {
-        if (datetime == null) {
-            return null;
-        }
-        final TemporalAccessor parsed = DateTimeFormatter.ISO_DATE_TIME.parse(datetime);
-        if (parsed.isSupported(ChronoField.OFFSET_SECONDS)) {
-            return ZonedDateTime.from(parsed).withZoneSameInstant(ZoneId.of("Europe/Oslo")).toLocalDateTime();
-        } else {
-            return LocalDateTime.from(parsed);
-        }
-    }
 
     public static Period EXAMPLE = new Period(
             LocalDateTime.of(2019, 5, 23, 10, 0, 0, 0)

--- a/src/main/java/no/digipost/api/datatypes/types/proof/Period.java
+++ b/src/main/java/no/digipost/api/datatypes/types/proof/Period.java
@@ -6,12 +6,12 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.Value;
 import lombok.With;
-import lombok.experimental.Wither;
 import no.digipost.api.datatypes.documentation.Description;
 import no.digipost.api.datatypes.validation.ValidPeriode;
 
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
@@ -25,15 +25,21 @@ import java.time.ZonedDateTime;
 public class Period {
     @XmlElement(name = "from")
     @Description("ISO8601 full DateTime")
-    ZonedDateTime from;
+    LocalDateTime from;
 
     @XmlElement(name = "to")
     @Description("ISO8601 full DateTime")
-    ZonedDateTime to;
+    LocalDateTime to;
+
+    @Deprecated
+    public Period(ZonedDateTime from, ZonedDateTime to) {
+        this(from != null ? from.withZoneSameInstant(ZoneId.of("Europe/Oslo")).toLocalDateTime() : null,
+             to != null ? to.withZoneSameInstant(ZoneId.of("Europe/Oslo")).toLocalDateTime() : null);
+    }
 
     public static Period EXAMPLE = new Period(
-            ZonedDateTime.of(2019, 5, 23, 10, 0, 0, 0, ZoneId.of("+0100"))
-            , ZonedDateTime.of(2019, 5, 23, 16, 0, 0, 0, ZoneId.of("+0100"))
+            LocalDateTime.of(2019, 5, 23, 10, 0, 0, 0)
+            , LocalDateTime.of(2019, 5, 23, 16, 0, 0, 0)
     );
 
     public String getISO8601() {

--- a/src/main/java/no/digipost/api/datatypes/types/proof/Period.java
+++ b/src/main/java/no/digipost/api/datatypes/types/proof/Period.java
@@ -1,5 +1,7 @@
 package no.digipost.api.datatypes.types.proof;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
@@ -14,6 +16,9 @@ import javax.xml.bind.annotation.XmlType;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoField;
+import java.time.temporal.TemporalAccessor;
 
 @XmlType
 @Value
@@ -32,9 +37,21 @@ public class Period {
     LocalDateTime to;
 
     @Deprecated
-    public Period(ZonedDateTime from, ZonedDateTime to) {
-        this(from != null ? from.withZoneSameInstant(ZoneId.of("Europe/Oslo")).toLocalDateTime() : null,
-             to != null ? to.withZoneSameInstant(ZoneId.of("Europe/Oslo")).toLocalDateTime() : null);
+    @JsonCreator
+    public Period(@JsonProperty("from") String from, @JsonProperty("to") String to) {
+        this(localDate(from), localDate(to));
+    }
+
+    private static LocalDateTime localDate(String datetime) {
+        if (datetime == null) {
+            return null;
+        }
+        final TemporalAccessor parsed = DateTimeFormatter.ISO_DATE_TIME.parse(datetime);
+        if (parsed.isSupported(ChronoField.OFFSET_SECONDS)) {
+            return ZonedDateTime.from(parsed).withZoneSameInstant(ZoneId.of("Europe/Oslo")).toLocalDateTime();
+        } else {
+            return LocalDateTime.from(parsed);
+        }
     }
 
     public static Period EXAMPLE = new Period(

--- a/src/main/java/no/digipost/api/datatypes/types/proof/Proof.java
+++ b/src/main/java/no/digipost/api/datatypes/types/proof/Proof.java
@@ -88,7 +88,7 @@ public class Proof implements DataType {
             new Proof(
                     "Bekkestua Bibliotek",
                     "#e1e1e1",
-                    ZonedDateTime.of(2019, 5, 23, 10, 0, 0, 0, ZoneId.systemDefault()),
+                    ZonedDateTime.of(2019, 5, 23, 10, 0, 0, 0, ZoneId.of("+02:00")),
                     ValidPeriod.EXAMPLE,
                     ProofHolder.EXAMPLE,
                     "Lånekort",

--- a/src/main/java/no/digipost/api/datatypes/types/proof/Proof.java
+++ b/src/main/java/no/digipost/api/datatypes/types/proof/Proof.java
@@ -5,7 +5,6 @@ import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import lombok.Value;
 import lombok.With;
-import lombok.experimental.Wither;
 import no.digipost.api.datatypes.DataType;
 import no.digipost.api.datatypes.documentation.Description;
 import no.digipost.api.datatypes.types.Info;

--- a/src/main/java/no/digipost/api/datatypes/types/proof/ProofHolder.java
+++ b/src/main/java/no/digipost/api/datatypes/types/proof/ProofHolder.java
@@ -5,7 +5,6 @@ import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import lombok.Value;
 import lombok.With;
-import lombok.experimental.Wither;
 import no.digipost.api.datatypes.documentation.Description;
 import no.digipost.api.datatypes.types.Address;
 

--- a/src/main/java/no/digipost/api/datatypes/types/proof/ValidPeriod.java
+++ b/src/main/java/no/digipost/api/datatypes/types/proof/ValidPeriod.java
@@ -5,7 +5,6 @@ import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import lombok.Value;
 import lombok.With;
-import lombok.experimental.Wither;
 import no.digipost.api.datatypes.documentation.Description;
 
 import javax.xml.bind.annotation.XmlAccessType;

--- a/src/main/java/no/digipost/api/datatypes/types/proof/YearlyRepeatingPeriod.java
+++ b/src/main/java/no/digipost/api/datatypes/types/proof/YearlyRepeatingPeriod.java
@@ -6,15 +6,12 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.Value;
 import lombok.With;
-import lombok.experimental.Wither;
 import no.digipost.api.datatypes.documentation.Description;
 
 import javax.validation.constraints.NotNull;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
-import java.time.Instant;
+import java.time.LocalDateTime;
 
 @XmlType
 @Value
@@ -44,39 +41,35 @@ public class YearlyRepeatingPeriod {
     public static YearlyRepeatingPeriod EXAMPLE = new YearlyRepeatingPeriod(
             2020,
             2022,
-            new CalendarDate(1, 1, null, null, null),
-            new CalendarDate(12, 31, 0, 0, "+01:00")
+            new CalendarDate(1, 1, null, null),
+            new CalendarDate(12, 31, 0, 0)
     );
     
     public String getISO8601() {
-        Instant now = Instant.now();
-        ZonedDateTime startDate = buildZonedDateTime(now, from, startYear);
-        ZonedDateTime endDate = buildZonedDateTime(now, to, endYear);
+        String startDate = writeLocalDate(from, startYear);
+        String endDate = writeLocalDate(to, endYear);
 
         if (startYear != null && endYear != null) {
             return "R/" + startDate + "/" + endDate;
         } else if (endYear != null) {
-            return "R/" + startDate.toString().substring(5) + "/" + endDate.toString();
+            return "R/" + startDate.substring(5) + "/" + endDate;
         } else if (startYear != null) {
-            return "R/" + startDate + "/" + endDate.toString().substring(5);
+            return "R/" + startDate + "/" + endDate.substring(5);
         } else {
-            return "R/" + startDate.toString().substring(5) + "/" + endDate.toString().substring(5);
+            return "R/" + startDate.substring(5) + "/" + endDate.substring(5);
         }
     }
 
-    private static ZonedDateTime buildZonedDateTime(Instant now, CalendarDate t_date, Integer year) {
+    private static String writeLocalDate(CalendarDate t_date, Integer year) {
         int t_minute = 0;
         int t_hour = 0;
         int t_day = 1;
         int t_month = 1;
-        ZoneId t_zone;
-        t_zone = t_date.getTimeZone() != null ? ZoneId.of(t_date.getTimeZone()) : ZoneId.of("+01:00");
         t_minute = t_date.getMin() != null ? t_date.getMin() : t_minute;
         t_hour = t_date.getHour() != null ? t_date.getHour() : t_hour;
         t_day = t_date.getDay() != null ? t_date.getDay() : t_day;
         t_month = t_date.getMonth() != null ? t_date.getMonth() : t_month;
-        ZonedDateTime nowInThatZone = now.atZone(t_zone);
-        int t_year = year != null ? year : nowInThatZone.getYear();
-        return ZonedDateTime.of(t_year, t_month, t_day, t_hour, t_minute, 0, 0, t_zone);
+        int t_year = year != null ? year : 2019; // note: the default value will be discarded, but we need it to create a LocalDateTime
+        return LocalDateTime.of(t_year, t_month, t_day, t_hour, t_minute, 0, 0).toString();
     }
 }

--- a/src/main/java/no/digipost/api/datatypes/types/proof/package-info.java
+++ b/src/main/java/no/digipost/api/datatypes/types/proof/package-info.java
@@ -2,11 +2,13 @@
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlJavaTypeAdapters({
         @XmlJavaTypeAdapter(ZonedDateTimeXmlAdapter.class),
+        @XmlJavaTypeAdapter(LocalDateTimeXmlAdapter.class)
 })
 @DataTypePackage
 package no.digipost.api.datatypes.types.proof;
 
 import no.digipost.api.datatypes.documentation.DataTypePackage;
+import no.digipost.api.datatypes.marshalling.LocalDateTimeXmlAdapter;
 import no.digipost.api.datatypes.marshalling.ZonedDateTimeXmlAdapter;
 
 import javax.xml.bind.annotation.XmlAccessType;

--- a/src/main/java/no/digipost/api/datatypes/types/receipt/Receipt.java
+++ b/src/main/java/no/digipost/api/datatypes/types/receipt/Receipt.java
@@ -135,7 +135,7 @@ public class Receipt implements DataType {
     public static Receipt EXAMPLE = new Receipt(
             "F96B6805-2453-478A-B58B-CCDFA07E21ED"
             , "364567"
-            , ZonedDateTime.of(2018, 5, 27, 10, 0, 0, 0, ZoneId.systemDefault())
+            , ZonedDateTime.of(2018, 5, 27, 10, 0, 0, 0, ZoneId.of("+02:00"))
             , ReceiptLine.EXAMPLE.getTotalPrice()
             , ReceiptLine.EXAMPLE.getTotalVat()
             , "NOK"

--- a/src/main/java/no/digipost/api/datatypes/types/receipt/TaxiDetails.java
+++ b/src/main/java/no/digipost/api/datatypes/types/receipt/TaxiDetails.java
@@ -53,8 +53,8 @@ public class TaxiDetails {
 
     public static final TaxiDetails EXAMPLE = new TaxiDetails(
             "EK99999", "12341ASDF", "123456789",
-            ZonedDateTime.of(2018, 6, 5, 10, 0, 0, 0, ZoneId.systemDefault()),
-            ZonedDateTime.of(2018, 6, 5, 10, 30, 0, 0, ZoneId.systemDefault()),
+            ZonedDateTime.of(2018, 6, 5, 10, 0, 0, 0, ZoneId.of("+02:00")),
+            ZonedDateTime.of(2018, 6, 5, 10, 30, 0, 0, ZoneId.of("+02:00")),
             new BigDecimal("8.00"), new BigDecimal("438.50"), 2000, 8500,
             6500, 320, 1220, 900,
             VatDetails.EXAMPLE);

--- a/src/test/java/no/digipost/api/datatypes/types/proof/TimePeriodTest.java
+++ b/src/test/java/no/digipost/api/datatypes/types/proof/TimePeriodTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -57,8 +58,8 @@ public class TimePeriodTest {
     @Test
     void deprecated_constructor_period_should_give_correct_norwegian_time() {
         Period period = new Period(
-                ZonedDateTime.of(2019, 8, 1, 0, 0, 0, 0, ZoneId.of("+02:00")),
-                ZonedDateTime.of(2022, 8, 1, 0, 0, 0, 0, ZoneId.of("+02:00"))
+                DateTimeFormatter.ISO_DATE_TIME.format(ZonedDateTime.of(2019, 8, 1, 0, 0, 0, 0, ZoneId.of("+02:00"))),
+                DateTimeFormatter.ISO_DATE_TIME.format(ZonedDateTime.of(2022, 8, 1, 0, 0, 0, 0, ZoneId.of("+02:00")))
         );
 
         assertThat(period.getISO8601(), equalTo("2019-08-01T00:00/2022-08-01T00:00"));

--- a/src/test/java/no/digipost/api/datatypes/types/proof/TimePeriodTest.java
+++ b/src/test/java/no/digipost/api/datatypes/types/proof/TimePeriodTest.java
@@ -56,16 +56,6 @@ public class TimePeriodTest {
     }
 
     @Test
-    void deprecated_constructor_period_should_give_correct_norwegian_time() {
-        Period period = new Period(
-                DateTimeFormatter.ISO_DATE_TIME.format(ZonedDateTime.of(2019, 8, 1, 0, 0, 0, 0, ZoneId.of("+02:00"))),
-                DateTimeFormatter.ISO_DATE_TIME.format(ZonedDateTime.of(2022, 8, 1, 0, 0, 0, 0, ZoneId.of("+02:00")))
-        );
-
-        assertThat(period.getISO8601(), equalTo("2019-08-01T00:00/2022-08-01T00:00"));
-    }
-
-    @Test
     void repeating_fra_til() {
         YearlyRepeatingPeriod period = new YearlyRepeatingPeriod(
                 2019, 2022

--- a/src/test/java/no/digipost/api/datatypes/types/proof/TimePeriodTest.java
+++ b/src/test/java/no/digipost/api/datatypes/types/proof/TimePeriodTest.java
@@ -3,6 +3,7 @@ package no.digipost.api.datatypes.types.proof;
 
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
@@ -16,37 +17,37 @@ public class TimePeriodTest {
     @Test
     void period_fra_til() {
         Period period = new Period(
-                ZonedDateTime.of(2019, 8, 1, 0, 0, 0, 0, ZoneId.of("+01:00")),
-                ZonedDateTime.of(2022, 8, 1, 0, 0, 0, 0, ZoneId.of("+01:00"))
+                LocalDateTime.of(2019, 8, 1, 0, 0, 0, 0),
+                LocalDateTime.of(2022, 8, 1, 0, 0, 0, 0)
         );
 
-        assertThat(period.getISO8601(), equalTo("2019-08-01T00:00+01:00/2022-08-01T00:00+01:00"));
+        assertThat(period.getISO8601(), equalTo("2019-08-01T00:00/2022-08-01T00:00"));
     }
 
     @Test
     void period_fra() {
         Period period = new Period(
-                ZonedDateTime.of(2019, 8, 1, 0, 0, 0, 0, ZoneId.of("+01:00")),
+                LocalDateTime.of(2019, 8, 1, 0, 0, 0, 0),
                 null
         );
 
-        assertThat(period.getISO8601(), equalTo("2019-08-01T00:00+01:00/.."));
+        assertThat(period.getISO8601(), equalTo("2019-08-01T00:00/.."));
     }
 
     @Test
     void period_til() {
         Period period = new Period(
                 null,
-                ZonedDateTime.of(2022, 8, 1, 0, 0, 0, 0, ZoneId.of("+01:00"))
+                LocalDateTime.of(2022, 8, 1, 0, 0, 0, 0)
         );
 
-        assertThat(period.getISO8601(), equalTo("../2022-08-01T00:00+01:00"));
+        assertThat(period.getISO8601(), equalTo("../2022-08-01T00:00"));
     }
 
     @Test
     void period() {
         Period period = new Period(
-                null,
+                (LocalDateTime) null,
                 null
         );
 
@@ -54,14 +55,24 @@ public class TimePeriodTest {
     }
 
     @Test
+    void deprecated_constructor_period_should_give_correct_norwegian_time() {
+        Period period = new Period(
+                ZonedDateTime.of(2019, 8, 1, 0, 0, 0, 0, ZoneId.of("+02:00")),
+                ZonedDateTime.of(2022, 8, 1, 0, 0, 0, 0, ZoneId.of("+02:00"))
+        );
+
+        assertThat(period.getISO8601(), equalTo("2019-08-01T00:00/2022-08-01T00:00"));
+    }
+
+    @Test
     void repeating_fra_til() {
         YearlyRepeatingPeriod period = new YearlyRepeatingPeriod(
                 2019, 2022
-                , new CalendarDate(5, 1, 0, 0, "+01:00")
+                , new CalendarDate(3, 1, 0, 0, "+01:00")
                 , new CalendarDate(10, 1, 0, 0, "+01:00")
         );
 
-        assertThat(period.getISO8601(), equalTo("R/2019-05-01T00:00+01:00/2022-10-01T00:00+01:00"));
+        assertThat(period.getISO8601(), equalTo("R/2019-03-01T00:00/2022-10-01T00:00"));
     }
 
     @Test
@@ -72,7 +83,7 @@ public class TimePeriodTest {
                 , new CalendarDate(10, 1, 0, 0, "+01:00")
         );
 
-        assertThat(period.getISO8601(), equalTo("R/05-01T00:00+01:00/2022-10-01T00:00+01:00"));
+        assertThat(period.getISO8601(), equalTo("R/05-01T00:00/2022-10-01T00:00"));
     }
 
     @Test
@@ -83,7 +94,7 @@ public class TimePeriodTest {
                 , new CalendarDate(10, 1, 0, 0, "+01:00")
         );
 
-        assertThat(period.getISO8601(), equalTo("R/2019-05-01T00:00+01:00/10-01T00:00+01:00"));
+        assertThat(period.getISO8601(), equalTo("R/2019-05-01T00:00/10-01T00:00"));
     }
 
     @Test
@@ -94,7 +105,7 @@ public class TimePeriodTest {
                 , new CalendarDate(10, 1, 0, 0, "+01:00")
         );
 
-        assertThat(period.getISO8601(), equalTo("R/05-01T00:00+01:00/10-01T00:00+01:00"));
+        assertThat(period.getISO8601(), equalTo("R/05-01T00:00/10-01T00:00"));
     }
 
     @Test
@@ -105,18 +116,18 @@ public class TimePeriodTest {
                 , new CalendarDate(10, 1, null, null, null)
         );
 
-        assertThat(period.getISO8601(), equalTo("R/05-01T00:00+01:00/10-01T00:00+01:00"));
+        assertThat(period.getISO8601(), equalTo("R/05-01T00:00/10-01T00:00"));
     }
 
     @Test
-    void repeating_esoteric_timezones() {
+    void repeating_discard_esoteric_timezones() {
         YearlyRepeatingPeriod period = new YearlyRepeatingPeriod(
                 null, null
                 , new CalendarDate(5, 1, 0, 0, "+03:00")
                 , new CalendarDate(10, 1, 0, 0, "+04:00")
         );
 
-        assertThat(period.getISO8601(), equalTo("R/05-01T00:00+03:00/10-01T00:00+04:00"));
+        assertThat(period.getISO8601(), equalTo("R/05-01T00:00/10-01T00:00"));
     }
 
 }


### PR DESCRIPTION
- Vi har kommet frem til at vi ønsker å bruke datoer og tidspunkter uten tidssoner

#### Ekstra

- Fiks en bug der gyldige XML-datetimes uten tidssone ble forkastet ved deserialisering til Java
- Ikke juster alle tidspunker inn i `systemDefault`-tidssone automagisk 😅 (men behold opprinnelig sone)
- Be jackson la være å drive med "contextual"-tidssone-sted-gjetting