### PR TITLE
bytt default fra null til evig timeinterval i iso8601-metode

### DIFF
--- a/src/main/java/no/digipost/api/datatypes/types/proof/ValidPeriod.java
+++ b/src/main/java/no/digipost/api/datatypes/types/proof/ValidPeriod.java
@@ -47,7 +47,7 @@ public class ValidPeriod {
         } else if (period != null) {
             return period.getISO8601();
         } else {
-            return null;
+            return "../..";
         }
     }
 


### PR DESCRIPTION
Vi ønsker ikke å returnere null fra denne metoden (det gjør den også likere de metodene den lener seg på, som er null-safe).

Det betyr at et Proof uten noen satt gyldighet eksplisitt alltid er gyldig.