### PR TITLE
Name for pickup-notice-recipient has been made optional

### DIFF
--- a/datatypes.xsd
+++ b/datatypes.xsd
@@ -284,7 +284,7 @@
 
   <xs:complexType final="extension restriction" name="recipient">
     <xs:sequence>
-      <xs:element name="name" type="xs:string"/>
+      <xs:element minOccurs="0" name="name" type="xs:string"/>
       <xs:element name="digipost-address" type="xs:string"/>
       <xs:element minOccurs="0" name="address" type="tns:address"/>
     </xs:sequence>

--- a/readme.md
+++ b/readme.md
@@ -505,7 +505,7 @@ Details about a pickup notice
 
 |Name|Type|Required|Description|
 |----|----|--------|-----------|
-|name|String|yes|The name of the recipient|
+|name|String|no|The name of the recipient|
 |digipostAddress|String|yes|The digipost address for the recipient|
 |address|[Address](#pickupnoticeaddress)|no||
 

--- a/src/main/java/no/digipost/api/datatypes/types/pickup/Recipient.java
+++ b/src/main/java/no/digipost/api/datatypes/types/pickup/Recipient.java
@@ -18,7 +18,7 @@ import javax.xml.bind.annotation.XmlType;
 @With
 public class Recipient {
 
-    @XmlElement(name = "name", required = true)
+    @XmlElement(name = "name")
     @Description("The name of the recipient")
     String name;
 


### PR DESCRIPTION
As per Postens request, name for recipient is now optional in PickupNotice