### PR TITLE
Nytt felt på PickupNotice: extraInformation

### DIFF
--- a/datatypes-examples.xml
+++ b/datatypes-examples.xml
@@ -212,6 +212,7 @@
         <cod-amount>0</cod-amount>
         <cod-fee>0</cod-fee>
     </cost>
+    <extra-information>Krever fremvisning av Pass eller Norsk nasjonalt ID-kort (Show Passport or Norwegian national ID-card). Fullmakt ikke tillatt.</extra-information>
     <status>READY_FOR_PICKUP</status>
     <tags>POSTEN</tags>
     <language>NB</language>

--- a/datatypes.xsd
+++ b/datatypes.xsd
@@ -240,6 +240,7 @@
             <xs:element name="pickup-place" type="tns:pickupPlace"/>
             <xs:element minOccurs="0" name="package" type="tns:package"/>
             <xs:element minOccurs="0" name="cost" type="tns:cost"/>
+            <xs:element minOccurs="0" name="extra-information" type="xs:string"/>
             <xs:element minOccurs="0" name="status" type="tns:status"/>
             <xs:element maxOccurs="unbounded" minOccurs="0" name="tags" type="tns:tag"/>
             <xs:element default="NB" minOccurs="0" name="language" type="tns:language"/>

--- a/readme.md
+++ b/readme.md
@@ -490,9 +490,10 @@ Details about a pickup notice
 |pickupPlace|[PickupPlace](#pickupnoticepickupplace)|yes|where the parcel can be fetched|
 |thePackage|[Package](#pickupnoticepackage)|no|package information|
 |cost|[Cost](#pickupnoticecost)|no|Information about value, mva, customs processing and more|
+|extraInformation|String|no|Additional information about the pickup. May for example be used to inform the recipient that identification will be required upon pickup.|
 |status|[Status](#pickupnoticestatus)|no|The state the package is at present time|
 |tags|Set|no|Tags to describe the document|
-|language|[Language](#pickupnoticelanguage)|no|Languange for the document|
+|language|[Language](#pickupnoticelanguage)|no|Language for the document|
 |link|[ExternalLink](#pickupnoticeexternallink)|no|An optional link to an external site, where the recipient can perform additional actions for their package|
 
 ### PickupNotice.Barcode
@@ -652,6 +653,7 @@ Valid values:
         <cod-amount>0</cod-amount>
         <cod-fee>0</cod-fee>
     </cost>
+    <extra-information>Krever fremvisning av Pass eller Norsk nasjonalt ID-kort (Show Passport or Norwegian national ID-card). Fullmakt ikke tillatt.</extra-information>
     <status>READY_FOR_PICKUP</status>
     <tags>POSTEN</tags>
     <language>NB</language>

--- a/src/main/java/no/digipost/api/datatypes/types/pickup/PickupNotice.java
+++ b/src/main/java/no/digipost/api/datatypes/types/pickup/PickupNotice.java
@@ -83,6 +83,10 @@ public class PickupNotice implements DataType {
     @XmlElement(name = "cost")
     @Description("Information about value, mva, customs processing and more")
     Cost cost;
+
+    @XmlElement(name = "extra-information")
+    @Description("Additional information about the pickup. May for example be used to inform the recipient that identification will be required upon pickup.")
+    String extraInformation;
     
     @XmlElement(name = "status")
     @Description("The state the package is at present time")
@@ -93,7 +97,7 @@ public class PickupNotice implements DataType {
     Set<Tag> tags;
 
     @XmlElement(defaultValue = "NB")
-    @Description("Languange for the document")
+    @Description("Language for the document")
     Language language;
 
     @XmlElement(name = "link")
@@ -122,6 +126,7 @@ public class PickupNotice implements DataType {
             , PickupPlace.EXAMPLE
             , Package.EXAMPLE
             , Cost.EXAMPLE
+            , "Krever fremvisning av Pass eller Norsk nasjonalt ID-kort (Show Passport or Norwegian national ID-card). Fullmakt ikke tillatt."
             , Status.READY_FOR_PICKUP
             , Collections.singleton(Tag.POSTEN)
             , Language.NB


### PR DESCRIPTION
Posten har behov for et nytt felt på hentelapp-metadataen, og de har gitt oss følgende eksempler på hva det kan inneholde:
- KONTRAKT MÅ SIGNERES VED UTLEVERING AV SENDING.
- Hentes man-fre 09-18, lør 09-15
- Personlig utlevering mot godkjent legitimasjon. Fullmakt ikke mulig
- Krever fremvisning av Pass eller Norsk nasjonalt ID-kort (Show Passport or Norwegian national ID-card). Fullmakt ikke tillatt
- UTLEVERING KREVER NOTERING AV GODKJENT LEGITIMASJON.

Når vi mottar feltet kalles det bare for `INFOTEKST`, og jeg har derfor gått for det litt vage navnet `extraInformation`. Så legger vi ikke noen føringer på hva det skal inneholde.