### PR TITLE
Parse DataType from json string to object without hinting of type

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -13,6 +13,7 @@ under the License.
 
 This project includes:
   Angus Activation Registries under EDL 1.0
+  Byte Buddy (without dependencies) under Apache License, Version 2.0
   ClassMate under Apache License, Version 2.0
   Digipost Data Types under The Apache Software License, Version 2.0
   Eclipse Expressly under Eclipse Public License v. 2.0 or GNU General Public License, version 2 with the GNU Classpath Exception

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <properties>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <lombok.version>1.18.30</lombok.version>
+        <lombok.version>1.18.32</lombok.version>
     </properties>
 
     <dependencyManagement>
@@ -24,14 +24,14 @@
             <dependency>
                 <groupId>com.fasterxml.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
-                <version>2.16.0</version>
+                <version>2.17.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
-                <version>5.5.2</version>
+                <version>5.10.2</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -69,7 +69,7 @@
         <dependency>
             <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <version>8.0.0.Final</version>
+            <version>8.0.1.Final</version>
             <scope>runtime</scope>
             <optional>true</optional>
         </dependency>
@@ -90,12 +90,12 @@
         <dependency>
             <groupId>jakarta.xml.bind</groupId>
             <artifactId>jakarta.xml.bind-api</artifactId>
-            <version>4.0.1</version>
+            <version>4.0.2</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-runtime</artifactId>
-            <version>4.0.4</version>
+            <version>4.0.5</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>
@@ -135,7 +135,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>2.0.7</version>
+            <version>2.0.13</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -272,12 +272,12 @@
                     <dependency>
                         <groupId>jakarta.xml.bind</groupId>
                         <artifactId>jakarta.xml.bind-api</artifactId>
-                        <version>4.0.1</version>
+                        <version>4.0.2</version>
                     </dependency>
                     <dependency>
                         <groupId>org.glassfish.jaxb</groupId>
                         <artifactId>jaxb-runtime</artifactId>
-                        <version>4.0.4</version>
+                        <version>4.0.5</version>
                         <scope>runtime</scope>
                     </dependency>
                 </dependencies>

--- a/src/main/java/no/digipost/api/datatypes/DataType.java
+++ b/src/main/java/no/digipost/api/datatypes/DataType.java
@@ -2,7 +2,46 @@ package no.digipost.api.datatypes;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import no.digipost.api.datatypes.types.Appointment;
+import no.digipost.api.datatypes.types.Boligdetaljer;
+import no.digipost.api.datatypes.types.Event;
+import no.digipost.api.datatypes.types.ExternalLink;
+import no.digipost.api.datatypes.types.Inkasso;
+import no.digipost.api.datatypes.types.Payslip;
+import no.digipost.api.datatypes.types.Residence;
+import no.digipost.api.datatypes.types.SignedDocument;
+import no.digipost.api.datatypes.types.invoice.Invoice;
+import no.digipost.api.datatypes.types.invoice.InvoicePayment;
+import no.digipost.api.datatypes.types.pickup.PickupNotice;
+import no.digipost.api.datatypes.types.pickup.PickupNoticeStatus;
+import no.digipost.api.datatypes.types.proof.Proof;
+import no.digipost.api.datatypes.types.receipt.Receipt;
+import no.digipost.api.datatypes.types.share.ShareDocumentsRequest;
+import no.digipost.api.datatypes.types.share.ShareDocumentsRequestDocumentsShared;
+import no.digipost.api.datatypes.types.share.ShareDocumentsRequestSharingStopped;
 
+@JsonTypeInfo(use = JsonTypeInfo.Id.SIMPLE_NAME, property = "type", include = JsonTypeInfo.As.EXISTING_PROPERTY)
+@JsonSubTypes({
+        @JsonSubTypes.Type(Appointment.class)
+        , @JsonSubTypes.Type(Residence.class)
+        , @JsonSubTypes.Type(ExternalLink.class)
+        , @JsonSubTypes.Type(Boligdetaljer.class)
+        , @JsonSubTypes.Type(Receipt.class)
+        , @JsonSubTypes.Type(Payslip.class)
+        , @JsonSubTypes.Type(SignedDocument.class)
+        , @JsonSubTypes.Type(PickupNotice.class)
+        , @JsonSubTypes.Type(PickupNoticeStatus.class)
+        , @JsonSubTypes.Type(Event.class)
+        , @JsonSubTypes.Type(Proof.class)
+        , @JsonSubTypes.Type(Inkasso.class)
+        , @JsonSubTypes.Type(Invoice.class)
+        , @JsonSubTypes.Type(InvoicePayment.class)
+        , @JsonSubTypes.Type(ShareDocumentsRequest.class)
+        , @JsonSubTypes.Type(ShareDocumentsRequestSharingStopped.class)
+        , @JsonSubTypes.Type(ShareDocumentsRequestDocumentsShared.class)
+})
 public interface DataType {
 
     @JsonProperty("type")

--- a/src/main/java/no/digipost/api/datatypes/DataTypeIdentifier.java
+++ b/src/main/java/no/digipost/api/datatypes/DataTypeIdentifier.java
@@ -77,17 +77,9 @@ public enum DataTypeIdentifier {
         this.example = example;
         complementables = Optional.ofNullable(getDataType().getAnnotation(ComplementedBy.class))
                 .map(ComplementedBy::value)
-                .map(Stream::of)
-                .orElseGet(Stream::empty)
+                .stream()
+                .flatMap(Stream::of)
                 .collect(collectingAndThen(toSet(), Collections::unmodifiableSet));
-    }
-
-    public Class<? extends DataType> getDataType() {
-        return dataType;
-    }
-
-    public String getShortName() {
-        return shortName;
     }
 
     public static DataTypeIdentifier fromRepresentationType(final Class<? extends DataType> representation) {
@@ -103,15 +95,23 @@ public enum DataTypeIdentifier {
             .orElseThrow(() -> new IllegalArgumentException("No value for " + DataTypeIdentifier.class.getSimpleName() + " found for shortName " + shortName));
     }
 
-    public DataType getExample() {
-        return example;
-    }
-
     public static Set<Class<? extends DataType>> getAllClasses() {
         return byType.keySet();
     }
 
     public boolean canBeComplementedBy(DataType successor) {
         return complementables.contains(successor.getClass());
+    }
+    
+    public Class<? extends DataType> getDataType() {
+        return dataType;
+    }
+
+    public String getShortName() {
+        return shortName;
+    }
+
+    public DataType getExample() {
+        return example;
     }
 }

--- a/src/test/java/no/digipost/api/datatypes/marshalling/MarshallingTest.java
+++ b/src/test/java/no/digipost/api/datatypes/marshalling/MarshallingTest.java
@@ -36,7 +36,7 @@ class MarshallingTest {
         try {
             ObjectMapper mapper = DataTypesJsonMapper.getMapper();
             final String json = mapper.writer().writeValueAsString(example.getExample());
-            final DataType unmarshalled = mapper.reader().forType(example.getDataType()).readValue(json);
+            final DataType unmarshalled = mapper.reader().forType(DataType.class).readValue(json);
             assertThat(unmarshalled, equalTo(example.getExample()));
         } catch (IOException e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
So, the problem is that when a DataType is serialized into json, the data structure that is the result has no type-information other than a property type="ImplementationType" in the json.
To be able to read json into a Java Object we do need to tell the objectReader what we want in return. Either you parse the json into a Map and check the magic property, or you store the type along side the json and use that to tell the objectMapper what type you want.

This change annotates the DataType interface with information on what property should be checked for type information and what implementations that are in existence. This gives us the ability to read a json text into a DataType without knowing the type it should result in.