### PR TITLE
DataType for accessing shared document in share-documents-request

### DIFF
--- a/datatypes-examples.xml
+++ b/datatypes-examples.xml
@@ -398,6 +398,20 @@
     <allowed-origin-organisation-numbers>984661185</allowed-origin-organisation-numbers>
 </share-documents-request>
 
+<share-documents-request-document-accessed xmlns="http://api.digipost.no/schema/datatypes">
+    <accessed-time>2024-09-16T10:00:00+02:00</accessed-time>
+    <accessed-by>Whoever Accessed</accessed-by>
+    <sharedDocumentData>
+        <delivery-time>2024-09-16T10:00:00+02:00</delivery-time>
+        <subject>Subject</subject>
+        <file-type>PDF</file-type>
+        <file-size-bytes>1</file-size-bytes>
+        <origin>
+            <organisation organisation-number="984661185" name="Posten Bring AS"/>
+        </origin>
+    </sharedDocumentData>
+</share-documents-request-document-accessed>
+
 <share-documents-request-documents-shared xmlns="http://api.digipost.no/schema/datatypes">
     <document-ids>123</document-ids>
 </share-documents-request-documents-shared>

--- a/datatypes.xsd
+++ b/datatypes.xsd
@@ -15,6 +15,7 @@
     <xs:element name="receipt" type="tns:receipt"/>
     <xs:element name="residence" type="tns:residence"/>
     <xs:element name="share-documents-request" type="tns:shareDocumentsRequest"/>
+    <xs:element name="share-documents-request-document-accessed" type="tns:shareDocumentsRequestDocumentAccessed"/>
     <xs:element name="share-documents-request-documents-shared" type="tns:shareDocumentsRequestDocumentsShared"/>
     <xs:element name="share-documents-request-sharing-stopped" type="tns:shareDocumentsRequestSharingStopped"/>
     <xs:element name="signedDocument" type="tns:signedDocument"/>
@@ -434,13 +435,47 @@
             <xs:element maxOccurs="10" minOccurs="0" name="allowed-origin-organisation-numbers" type="xs:string"/>
         </xs:sequence>
     </xs:complexType>
+    <xs:complexType final="extension restriction" name="shareDocumentsRequestDocumentAccessed">
+        <xs:sequence>
+            <xs:element name="accessed-time" type="xs:string"/>
+            <xs:element name="accessed-by" type="xs:string"/>
+            <xs:element name="sharedDocumentData" type="tns:sharedDocumentData"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType final="extension restriction" name="sharedDocumentData">
+        <xs:sequence>
+            <xs:element name="delivery-time" type="xs:string"/>
+            <xs:element name="subject" type="xs:string"/>
+            <xs:element name="file-type" type="xs:string"/>
+            <xs:element name="file-size-bytes" type="xs:integer"/>
+            <xs:element name="origin" type="tns:sharedDocumentOrigin"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType final="extension restriction" name="sharedDocumentOrigin">
+        <xs:sequence>
+            <xs:element minOccurs="0" name="private-person" type="tns:sharedDocumentOriginPrivatePerson"/>
+            <xs:element minOccurs="0" name="organisation" type="tns:sharedDocumentOriginOrganisation"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType final="extension restriction" name="sharedDocumentOriginPrivatePerson">
+        <xs:sequence/>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+    <xs:complexType final="extension restriction" name="sharedDocumentOriginOrganisation">
+        <xs:sequence/>
+        <xs:attribute name="organisation-number" type="xs:string" use="required"/>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
     <xs:complexType final="extension restriction" name="shareDocumentsRequestDocumentsShared">
         <xs:sequence>
             <xs:element maxOccurs="unbounded" minOccurs="0" name="document-ids" type="xs:long"/>
         </xs:sequence>
     </xs:complexType>
     <xs:complexType final="extension restriction" name="shareDocumentsRequestSharingStopped">
-        <xs:sequence/>
+        <xs:sequence>
+            <xs:element minOccurs="0" name="messaging-party" type="tns:messagingParty"/>
+            <xs:element minOccurs="0" name="name" type="xs:string"/>
+        </xs:sequence>
     </xs:complexType>
     <xs:simpleType name="language">
         <xs:restriction base="xs:string">
@@ -463,6 +498,12 @@
             <xs:enumeration value="RETURNED"/>
             <xs:enumeration value="UNKNOWN"/>
             <xs:enumeration value="DEVIATION"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="messagingParty">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="SENDER"/>
+            <xs:enumeration value="RECEIVER"/>
         </xs:restriction>
     </xs:simpleType>
 </xs:schema>

--- a/readme.md
+++ b/readme.md
@@ -16,6 +16,7 @@
 |[Receipt](#receipt)|Receipt represents a document containing details about a purchase|
 |[Residence](#residence)|Residence is a way of linking separate data for the same residence|
 |[ShareDocumentsRequest](#sharedocumentsrequest)|A request for a user to share one or more documents|
+|[ShareDocumentsRequestDocumentAccessed](#sharedocumentsrequestdocumentaccessed)|Documents have been accessed for ShareDocumentsRequest by the receiver.|
 |[ShareDocumentsRequestDocumentsShared](#sharedocumentsrequestdocumentsshared)|Documents have been shared for ShareDocumentsRequest|
 |[ShareDocumentsRequestSharingStopped](#sharedocumentsrequestsharingstopped)|Stop sharing of documents for ShareDocumentsRequest|
 |[SignedDocument](#signeddocument)|Details about a signed document|
@@ -1110,6 +1111,66 @@ A request for a user to share one or more documents
 </share-documents-request>
 ```
 
+## ShareDocumentsRequestDocumentAccessed
+
+Documents have been accessed for ShareDocumentsRequest by the receiver.
+
+### Fields
+
+|Name|Type|Required|Description|
+|----|----|--------|-----------|
+|accessedTime|ZonedDateTime|yes|The point of time the document was accessed,|
+|accessedBy|String|yes|Name of the person or organisation who accessed the shared document.|
+|sharedDocumentData|[SharedDocumentData](#sharedocumentsrequestdocumentaccessedshareddocumentdata)|yes||
+
+### ShareDocumentsRequestDocumentAccessed.SharedDocumentData
+
+|Name|Type|Required|Description|
+|----|----|--------|-----------|
+|deliveryTime|ZonedDateTime|yes||
+|subject|String|yes||
+|fileType|String|yes||
+|fileSizeBytes|BigInteger|yes||
+|origin|[SharedDocumentOrigin](#sharedocumentsrequestdocumentaccessedshareddocumentorigin)|yes||
+
+### ShareDocumentsRequestDocumentAccessed.SharedDocumentOrigin
+
+|Name|Type|Required|Description|
+|----|----|--------|-----------|
+|privatePerson|[SharedDocumentOriginPrivatePerson](#sharedocumentsrequestdocumentaccessedshareddocumentoriginprivateperson)|no||
+|organisation|[SharedDocumentOriginOrganisation](#sharedocumentsrequestdocumentaccessedshareddocumentoriginorganisation)|no||
+
+### ShareDocumentsRequestDocumentAccessed.SharedDocumentOriginPrivatePerson
+
+|Name|Type|Required|Description|
+|----|----|--------|-----------|
+|name|String|no||
+
+### ShareDocumentsRequestDocumentAccessed.SharedDocumentOriginOrganisation
+
+|Name|Type|Required|Description|
+|----|----|--------|-----------|
+|organisationNumber|String|no||
+|name|String|no||
+
+### XML
+
+```xml
+<share-documents-request-document-accessed xmlns="http://api.digipost.no/schema/datatypes">
+    <accessed-time>2024-09-16T10:00:00+02:00</accessed-time>
+    <accessed-by>Whoever Accessed</accessed-by>
+    <sharedDocumentData>
+        <delivery-time>2024-09-16T10:00:00+02:00</delivery-time>
+        <subject>Subject</subject>
+        <file-type>PDF</file-type>
+        <file-size-bytes>1</file-size-bytes>
+        <origin>
+            <organisation organisation-number="984661185" name="Posten Bring AS"/>
+        </origin>
+    </sharedDocumentData>
+</share-documents-request-document-accessed>
+```
+
 ## ShareDocumentsRequestDocumentsShared
 
 Documents have been shared for ShareDocumentsRequest
@@ -1136,7 +1197,15 @@ Stop sharing of documents for ShareDocumentsRequest
 
 |Name|Type|Required|Description|
 |----|----|--------|-----------|
+|messagingParty|[MessagingParty](#sharedocumentsrequestsharingstoppedmessagingparty)|no|Whether the sharing was stopped by the sender or receiver.|
+|name|String|no|Name of the person or administrator who stopped the sharing.|
 
+### ShareDocumentsRequestSharingStopped.MessagingParty
+
+Valid values:
+
+* SENDER
+* RECEIVER
 
 ### XML
 

--- a/src/main/java/no/digipost/api/datatypes/DataType.java
+++ b/src/main/java/no/digipost/api/datatypes/DataType.java
@@ -19,6 +19,7 @@ import no.digipost.api.datatypes.types.pickup.PickupNoticeStatus;
 import no.digipost.api.datatypes.types.proof.Proof;
 import no.digipost.api.datatypes.types.receipt.Receipt;
 import no.digipost.api.datatypes.types.share.ShareDocumentsRequest;
+import no.digipost.api.datatypes.types.share.ShareDocumentsRequestDocumentAccessed;
 import no.digipost.api.datatypes.types.share.ShareDocumentsRequestDocumentsShared;
 import no.digipost.api.datatypes.types.share.ShareDocumentsRequestSharingStopped;
 
@@ -41,6 +42,7 @@ import no.digipost.api.datatypes.types.share.ShareDocumentsRequestSharingStopped
         , @JsonSubTypes.Type(ShareDocumentsRequest.class)
         , @JsonSubTypes.Type(ShareDocumentsRequestSharingStopped.class)
         , @JsonSubTypes.Type(ShareDocumentsRequestDocumentsShared.class)
+        , @JsonSubTypes.Type(ShareDocumentsRequestDocumentAccessed.class)
 })
 public interface DataType {
 

--- a/src/main/java/no/digipost/api/datatypes/DataTypeIdentifier.java
+++ b/src/main/java/no/digipost/api/datatypes/DataTypeIdentifier.java
@@ -15,6 +15,7 @@ import no.digipost.api.datatypes.types.pickup.PickupNoticeStatus;
 import no.digipost.api.datatypes.types.proof.Proof;
 import no.digipost.api.datatypes.types.receipt.Receipt;
 import no.digipost.api.datatypes.types.share.ShareDocumentsRequest;
+import no.digipost.api.datatypes.types.share.ShareDocumentsRequestDocumentAccessed;
 import no.digipost.api.datatypes.types.share.ShareDocumentsRequestDocumentsShared;
 import no.digipost.api.datatypes.types.share.ShareDocumentsRequestSharingStopped;
 
@@ -56,6 +57,7 @@ public enum DataTypeIdentifier {
     , SHARE_DOCUMENT_REQUEST(ShareDocumentsRequest.class, "SHAR", ShareDocumentsRequest.EXAMPLE)
     , SHARE_DOCUMENT_REQUEST_SHARING_STOPPED(ShareDocumentsRequestSharingStopped.class, "SHSS", ShareDocumentsRequestSharingStopped.EXAMPLE)
     , SHARE_DOCUMENT_REQUEST_DOCUMENTS_SHARED(ShareDocumentsRequestDocumentsShared.class, "SHDS", ShareDocumentsRequestDocumentsShared.EXAMPLE)
+    , SHARE_DOCUMENT_REQUEST_DOCUMENT_ACCESSED(ShareDocumentsRequestDocumentAccessed.class, "SHDA", ShareDocumentsRequestDocumentAccessed.EXAMPLE)
     ;
 
     private final Class<? extends DataType> dataType;

--- a/src/main/java/no/digipost/api/datatypes/types/share/MessagingParty.java
+++ b/src/main/java/no/digipost/api/datatypes/types/share/MessagingParty.java
@@ -1,0 +1,6 @@
+package no.digipost.api.datatypes.types.share;
+
+public enum MessagingParty {
+    SENDER,
+    RECEIVER
+}

--- a/src/main/java/no/digipost/api/datatypes/types/share/ShareDocumentsRequestDocumentAccessed.java
+++ b/src/main/java/no/digipost/api/datatypes/types/share/ShareDocumentsRequestDocumentAccessed.java
@@ -1,0 +1,43 @@
+package no.digipost.api.datatypes.types.share;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.Value;
+import lombok.With;
+import no.digipost.api.datatypes.DataType;
+import no.digipost.api.datatypes.documentation.Description;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+@XmlRootElement(name = "share-documents-request-document-accessed")
+@Value
+@AllArgsConstructor
+@NoArgsConstructor(force = true, access = AccessLevel.PRIVATE)
+@With
+@Description("Documents have been accessed for ShareDocumentsRequest by the receiver.")
+public class ShareDocumentsRequestDocumentAccessed implements DataType {
+
+    @XmlElement(name = "accessed-time", required = true)
+    @Description("The point of time the document was accessed,")
+    ZonedDateTime accessedTime;
+
+    @XmlElement(name="accessed-by", required = true)
+    @NotNull
+    @Description("Name of the person or organisation who accessed the shared document.")
+    String accessedBy;
+
+    @XmlElement(required = true)
+    SharedDocumentData sharedDocumentData;
+
+    public static final ShareDocumentsRequestDocumentAccessed EXAMPLE = new ShareDocumentsRequestDocumentAccessed(
+            ZonedDateTime.of(2024, 9, 16, 10, 0, 0, 0, ZoneId.of("+02:00")),
+            "Whoever Accessed",
+            SharedDocumentData.EXAMPLE
+    );
+
+}

--- a/src/main/java/no/digipost/api/datatypes/types/share/ShareDocumentsRequestSharingStopped.java
+++ b/src/main/java/no/digipost/api/datatypes/types/share/ShareDocumentsRequestSharingStopped.java
@@ -1,7 +1,9 @@
 package no.digipost.api.datatypes.types.share;
 
+import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import lombok.Value;
 import lombok.With;
@@ -10,10 +12,19 @@ import no.digipost.api.datatypes.documentation.Description;
 
 @XmlRootElement(name = "share-documents-request-sharing-stopped")
 @Value
+@AllArgsConstructor
 @NoArgsConstructor(force = true, access = AccessLevel.PUBLIC)
 @With
 @Description("Stop sharing of documents for ShareDocumentsRequest")
 public class ShareDocumentsRequestSharingStopped implements DataType {
+
+    @XmlElement(name="messaging-party", required = false)
+    @Description("Whether the sharing was stopped by the sender or receiver.")
+    MessagingParty messagingParty;
+
+    @XmlElement(name="name", required = false)
+    @Description("Name of the person or administrator who stopped the sharing.")
+    String name;
 
     public static final ShareDocumentsRequestSharingStopped EXAMPLE = new ShareDocumentsRequestSharingStopped();
 

--- a/src/main/java/no/digipost/api/datatypes/types/share/SharedDocumentData.java
+++ b/src/main/java/no/digipost/api/datatypes/types/share/SharedDocumentData.java
@@ -1,0 +1,47 @@
+package no.digipost.api.datatypes.types.share;
+
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlType;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.Value;
+import lombok.With;
+import no.digipost.api.datatypes.documentation.Description;
+
+import java.math.BigInteger;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+@XmlType
+@Value
+@AllArgsConstructor
+@NoArgsConstructor(force = true, access = AccessLevel.PRIVATE)
+@With
+@Description("Contains details about a shared document")
+public class SharedDocumentData {
+
+    @XmlElement(name = "delivery-time", required = true)
+    ZonedDateTime deliveryTime;
+
+    @XmlElement(required = true)
+    String subject;
+
+    @XmlElement(name = "file-type", required = true)
+    String fileType;
+
+    @XmlElement(name = "file-size-bytes", required = true)
+    BigInteger fileSizeBytes;
+
+    @XmlElement(required = true)
+    SharedDocumentOrigin origin;
+
+    public static final SharedDocumentData EXAMPLE = new SharedDocumentData(
+            ZonedDateTime.of(2024, 9, 16, 10, 0, 0, 0, ZoneId.of("+02:00")),
+            "Subject",
+            "PDF",
+            BigInteger.ONE,
+            new SharedDocumentOrigin().withOrganisation(SharedDocumentOriginOrganisation.EXAMPLE)
+    );
+
+}

--- a/src/main/java/no/digipost/api/datatypes/types/share/SharedDocumentOrigin.java
+++ b/src/main/java/no/digipost/api/datatypes/types/share/SharedDocumentOrigin.java
@@ -1,0 +1,25 @@
+package no.digipost.api.datatypes.types.share;
+
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlType;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.Value;
+import lombok.With;
+import no.digipost.api.datatypes.documentation.Description;
+
+@XmlType
+@Value
+@AllArgsConstructor
+@NoArgsConstructor(force = true, access = AccessLevel.PUBLIC)
+@With
+@Description("Contains details about a single item (line) on the receipt")
+public class SharedDocumentOrigin {
+
+    @XmlElement(name = "private-person", required = false)
+    SharedDocumentOriginPrivatePerson privatePerson;
+    @XmlElement(name = "organisation", required = false)
+    SharedDocumentOriginOrganisation organisation;
+
+}

--- a/src/main/java/no/digipost/api/datatypes/types/share/SharedDocumentOriginOrganisation.java
+++ b/src/main/java/no/digipost/api/datatypes/types/share/SharedDocumentOriginOrganisation.java
@@ -1,0 +1,30 @@
+package no.digipost.api.datatypes.types.share;
+
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlType;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.Value;
+import lombok.With;
+import no.digipost.api.datatypes.documentation.Description;
+
+@XmlType
+@Value
+@AllArgsConstructor
+@NoArgsConstructor(force = true, access = AccessLevel.PRIVATE)
+@With
+@Description("Origin of shared document is an organisation")
+public class SharedDocumentOriginOrganisation {
+
+    @XmlAttribute(name = "organisation-number", required = true)
+    String organisationNumber;
+    @XmlAttribute(name = "name", required = true)
+    String name;
+
+    public static final SharedDocumentOriginOrganisation EXAMPLE = new SharedDocumentOriginOrganisation(
+            "984661185",
+            "Posten Bring AS"
+    );
+
+}

--- a/src/main/java/no/digipost/api/datatypes/types/share/SharedDocumentOriginPrivatePerson.java
+++ b/src/main/java/no/digipost/api/datatypes/types/share/SharedDocumentOriginPrivatePerson.java
@@ -1,0 +1,27 @@
+package no.digipost.api.datatypes.types.share;
+
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlType;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.Value;
+import lombok.With;
+import no.digipost.api.datatypes.documentation.Description;
+
+@XmlType
+@Value
+@AllArgsConstructor
+@NoArgsConstructor(force = true, access = AccessLevel.PRIVATE)
+@With
+@Description("Origin of shared document is a private person")
+public class SharedDocumentOriginPrivatePerson {
+
+    @XmlAttribute(name = "name", required = true)
+    String name;
+
+    public static final SharedDocumentOriginPrivatePerson EXAMPLE = new SharedDocumentOriginPrivatePerson(
+            "Test Testesen"
+    );
+
+}

--- a/src/main/resources/no/digipost/api/datatypes/types/jaxb.index
+++ b/src/main/resources/no/digipost/api/datatypes/types/jaxb.index
@@ -15,3 +15,4 @@ Inkasso
 share.ShareDocumentsRequest
 share.ShareDocumentsRequestSharingStopped
 share.ShareDocumentsRequestDocumentsShared
+share.ShareDocumentsRequestDocumentAccessed


### PR DESCRIPTION
We want to register when and by who a shared document has been accessed. These events must contain all necessary information regarding the shared document, because metadata about the shared document itself is not known once the sharing has stopped. This enables both sender and receiver to see a history of access even after the sharing is stopped.

Additionally, the SharingStopped type is extended with optional fields explaining which party stopped the sharing. This is especially important for senders, who may be confused by the state of their sharing request in the event that the receiver stops the sharing before the sender has had the chance to access the shared document.