### PR TITLE
Lag datatyper for signering i Digipost

### DIFF
--- a/datatypes-examples.xml
+++ b/datatypes-examples.xml
@@ -413,6 +413,28 @@
 
 <share-documents-request-sharing-stopped xmlns="http://api.digipost.no/schema/datatypes"/>
 
+<signing-request xmlns="http://api.digipost.no/schema/datatypes">
+    <oppdrag-ref>264f2cf0-6cd9-4a26-9f9f-560d0df7e69a</oppdrag-ref>
+    <gyldig-til>2026-05-31T23:59:00+02:00</gyldig-til>
+    <signatarer>
+        <digipostadresse>ola.nordmann#1234</digipostadresse>
+        <navn>Ola Nordmann</navn>
+    </signatarer>
+    <signatarer>
+        <digipostadresse>kari.nordmann#1234</digipostadresse>
+        <navn>Kari Nordmann</navn>
+    </signatarer>
+</signing-request>
+
+<signing-completed-by xmlns="http://api.digipost.no/schema/datatypes">
+    <digipostadresse>ola.nordmann#1234</digipostadresse>
+</signing-completed-by>
+
+<signing-rejected-by xmlns="http://api.digipost.no/schema/datatypes">
+    <digipostadresse>kari.nordmann#1234</digipostadresse>
+</signing-rejected-by>
+
+
 <signedDocument xmlns="http://api.digipost.no/schema/datatypes">
     <document-issuer>Bedrift AS</document-issuer>
     <document-subject>Ansettelseskontrakt</document-subject>

--- a/datatypes.xsd
+++ b/datatypes.xsd
@@ -56,6 +56,15 @@
   <xs:element name="share-documents-request-sharing-stopped" type="tns:shareDocumentsRequestSharingStopped"/>
       
   
+  <xs:element name="signing-request" type="tns:signingRequest"/>
+
+
+  <xs:element name="signing-completed-by" type="tns:signingCompletedBy"/>
+
+
+  <xs:element name="signing-rejected-by" type="tns:signingRejectedBy"/>
+
+
   <xs:element name="signedDocument" type="tns:signedDocument"/>
       
   
@@ -1365,11 +1374,80 @@
             
     
     <xs:sequence/>
-          
-  
+
+
   </xs:complexType>
-      
-  
+
+
+  <xs:complexType final="extension restriction" name="signatar">
+
+
+    <xs:sequence>
+
+
+      <xs:element name="digipostadresse" type="xs:string"/>
+
+
+      <xs:element name="navn" type="xs:string"/>
+
+
+    </xs:sequence>
+
+
+  </xs:complexType>
+
+
+  <xs:complexType final="extension restriction" name="signingRequest">
+
+
+    <xs:sequence>
+
+
+      <xs:element name="oppdrag-ref" type="xs:string"/>
+
+
+      <xs:element name="gyldig-til" type="xs:dateTime"/>
+
+
+      <xs:element maxOccurs="unbounded" name="signatarer" type="tns:signatar"/>
+
+
+    </xs:sequence>
+
+
+  </xs:complexType>
+
+
+  <xs:complexType final="extension restriction" name="signingCompletedBy">
+
+
+    <xs:sequence>
+
+
+      <xs:element name="digipostadresse" type="xs:string"/>
+
+
+    </xs:sequence>
+
+
+  </xs:complexType>
+
+
+  <xs:complexType final="extension restriction" name="signingRejectedBy">
+
+
+    <xs:sequence>
+
+
+      <xs:element name="digipostadresse" type="xs:string"/>
+
+
+    </xs:sequence>
+
+
+  </xs:complexType>
+
+
   <xs:complexType final="extension restriction" name="verifiableCredentialNotice">
             
     

--- a/src/main/java/no/digipost/api/datatypes/DataType.java
+++ b/src/main/java/no/digipost/api/datatypes/DataType.java
@@ -20,6 +20,9 @@ import no.digipost.api.datatypes.types.pickup.PickupNotice;
 import no.digipost.api.datatypes.types.pickup.PickupNoticeStatus;
 import no.digipost.api.datatypes.types.proof.Proof;
 import no.digipost.api.datatypes.types.receipt.Receipt;
+import no.digipost.api.datatypes.types.signing.SigningCompletedBy;
+import no.digipost.api.datatypes.types.signing.SigningRejectedBy;
+import no.digipost.api.datatypes.types.signing.SigningRequest;
 import no.digipost.api.datatypes.types.share.ShareDocumentsRequest;
 import no.digipost.api.datatypes.types.share.ShareDocumentsRequestDocumentsShared;
 import no.digipost.api.datatypes.types.share.ShareDocumentsRequestSharingStopped;
@@ -45,6 +48,9 @@ import no.digipost.api.datatypes.types.verifiableCredential.VerifiablePresentati
         , @JsonSubTypes.Type(ShareDocumentsRequest.class)
         , @JsonSubTypes.Type(ShareDocumentsRequestSharingStopped.class)
         , @JsonSubTypes.Type(ShareDocumentsRequestDocumentsShared.class)
+        , @JsonSubTypes.Type(SigningRequest.class)
+        , @JsonSubTypes.Type(SigningCompletedBy.class)
+        , @JsonSubTypes.Type(SigningRejectedBy.class)
         , @JsonSubTypes.Type(OpeningReceipt.class)
         , @JsonSubTypes.Type(OpeningReceiptAccepted.class)
         , @JsonSubTypes.Type(VerifiableCredentialNotice.class)

--- a/src/main/java/no/digipost/api/datatypes/DataTypeIdentifier.java
+++ b/src/main/java/no/digipost/api/datatypes/DataTypeIdentifier.java
@@ -16,6 +16,9 @@ import no.digipost.api.datatypes.types.pickup.PickupNotice;
 import no.digipost.api.datatypes.types.pickup.PickupNoticeStatus;
 import no.digipost.api.datatypes.types.proof.Proof;
 import no.digipost.api.datatypes.types.receipt.Receipt;
+import no.digipost.api.datatypes.types.signing.SigningCompletedBy;
+import no.digipost.api.datatypes.types.signing.SigningRejectedBy;
+import no.digipost.api.datatypes.types.signing.SigningRequest;
 import no.digipost.api.datatypes.types.share.ShareDocumentsRequest;
 import no.digipost.api.datatypes.types.share.ShareDocumentsRequestDocumentsShared;
 import no.digipost.api.datatypes.types.share.ShareDocumentsRequestSharingStopped;
@@ -60,6 +63,9 @@ public enum DataTypeIdentifier {
     , SHARE_DOCUMENT_REQUEST(ShareDocumentsRequest.class, "SHAR", ShareDocumentsRequest.EXAMPLE)
     , SHARE_DOCUMENT_REQUEST_SHARING_STOPPED(ShareDocumentsRequestSharingStopped.class, "SHSS", ShareDocumentsRequestSharingStopped.EXAMPLE)
     , SHARE_DOCUMENT_REQUEST_DOCUMENTS_SHARED(ShareDocumentsRequestDocumentsShared.class, "SHDS", ShareDocumentsRequestDocumentsShared.EXAMPLE)
+    , SIGNING_REQUEST(SigningRequest.class, "SIGR", SigningRequest.EXAMPLE)
+    , SIGNING_COMPLETED_BY(SigningCompletedBy.class, "SIGC", SigningCompletedBy.EXAMPLE)
+    , SIGNING_REJECTED_BY(SigningRejectedBy.class, "SIGX", SigningRejectedBy.EXAMPLE)
     , OPENING_RECEIPT(OpeningReceipt.class, "OPRC", OpeningReceipt.EXAMPLE)
     , OPENING_RECEIPT_ACCEPTED(OpeningReceiptAccepted.class, "OPAC", OpeningReceiptAccepted.EXAMPLE)
     , VERIFIABLE_CREDENTIAL_NOTICE(VerifiableCredentialNotice.class, "VCNO", VerifiableCredentialNotice.EXAMPLE)

--- a/src/main/java/no/digipost/api/datatypes/types/signing/Signatar.java
+++ b/src/main/java/no/digipost/api/datatypes/types/signing/Signatar.java
@@ -1,0 +1,31 @@
+package no.digipost.api.datatypes.types.signing;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlType;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.Value;
+import lombok.With;
+import no.digipost.api.datatypes.documentation.Description;
+
+@XmlType
+@Value
+@AllArgsConstructor
+@NoArgsConstructor(force = true, access = AccessLevel.PRIVATE)
+@With
+public class Signatar {
+
+    @XmlElement(name = "digipostadresse", required = true)
+    @Description("Digipost address of the signer.")
+    @NotBlank
+    String digipostadresse;
+
+    @XmlElement(name = "navn")
+    @Description("Full name of the signer.")
+    String navn;
+
+    public static final Signatar EXAMPLE = new Signatar("ola.nordmann#1234", "Ola Nordmann");
+}
+

--- a/src/main/java/no/digipost/api/datatypes/types/signing/SigningCompletedBy.java
+++ b/src/main/java/no/digipost/api/datatypes/types/signing/SigningCompletedBy.java
@@ -1,0 +1,31 @@
+package no.digipost.api.datatypes.types.signing;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.Value;
+import lombok.With;
+import no.digipost.api.datatypes.ComplementedBy;
+import no.digipost.api.datatypes.DataType;
+import no.digipost.api.datatypes.documentation.Description;
+
+@XmlRootElement(name = "signing-completed-by")
+@Value
+@AllArgsConstructor
+@NoArgsConstructor(force = true, access = AccessLevel.PRIVATE)
+@With
+@Description("Signals that one signer has completed signing.")
+@ComplementedBy(SigningCompletedBy.class)
+public class SigningCompletedBy implements DataType {
+
+    @XmlElement(name = "digipostadresse", required = true)
+    @Description("Digipost address for the signer who completed signing.")
+    @NotBlank
+    String digipostadresse;
+
+    public static final SigningCompletedBy EXAMPLE = new SigningCompletedBy("ola.nordmann#1234");
+}
+

--- a/src/main/java/no/digipost/api/datatypes/types/signing/SigningRejectedBy.java
+++ b/src/main/java/no/digipost/api/datatypes/types/signing/SigningRejectedBy.java
@@ -1,0 +1,29 @@
+package no.digipost.api.datatypes.types.signing;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.Value;
+import lombok.With;
+import no.digipost.api.datatypes.DataType;
+import no.digipost.api.datatypes.documentation.Description;
+
+@XmlRootElement(name = "signing-rejected-by")
+@Value
+@AllArgsConstructor
+@NoArgsConstructor(force = true, access = AccessLevel.PRIVATE)
+@With
+@Description("Signals that one signer has rejected the signing request.")
+public class SigningRejectedBy implements DataType {
+
+    @XmlElement(name = "digipostadresse", required = true)
+    @Description("Digipost address for the signer who rejected signing.")
+    @NotBlank
+    String digipostadresse;
+
+    public static final SigningRejectedBy EXAMPLE = new SigningRejectedBy("kari.nordmann#1234");
+}
+

--- a/src/main/java/no/digipost/api/datatypes/types/signing/SigningRequest.java
+++ b/src/main/java/no/digipost/api/datatypes/types/signing/SigningRequest.java
@@ -1,0 +1,56 @@
+package no.digipost.api.datatypes.types.signing;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.Value;
+import lombok.With;
+import no.digipost.api.datatypes.ComplementedBy;
+import no.digipost.api.datatypes.DataType;
+import no.digipost.api.datatypes.documentation.Description;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@XmlRootElement(name = "signing-request")
+@Value
+@AllArgsConstructor
+@NoArgsConstructor(force = true, access = AccessLevel.PRIVATE)
+@With
+@Description("A signing request in Digipost's internal signing flow.")
+@ComplementedBy({SigningCompletedBy.class, SigningRejectedBy.class})
+public class SigningRequest implements DataType {
+
+    @XmlElement(name = "oppdrag-ref", required = true)
+    @Description("UUID reference to the signing assignment.")
+    @NotNull
+    UUID oppdragRef;
+
+    @XmlElement(name = "gyldig-til", required = true)
+    @Description("When the signing request expires. ISO8601 full DateTime with timezone.")
+    @NotNull
+    ZonedDateTime gyldigTil;
+
+    @XmlElement(name = "signatarer", required = true)
+    @Description("Non-empty list of signers.")
+    @NotEmpty
+    @Valid
+    List<Signatar> signatarer;
+
+    public static final SigningRequest EXAMPLE = new SigningRequest(
+            UUID.fromString("264f2cf0-6cd9-4a26-9f9f-560d0df7e69a"),
+            ZonedDateTime.of(2026, 5, 31, 23, 59, 0, 0, ZoneId.of("+02:00")),
+            List.of(
+                    Signatar.EXAMPLE,
+                    new Signatar("kari.nordmann#1234", "Kari Nordmann")
+            )
+    );
+}
+

--- a/src/main/java/no/digipost/api/datatypes/types/signing/package-info.java
+++ b/src/main/java/no/digipost/api/datatypes/types/signing/package-info.java
@@ -1,0 +1,15 @@
+@XmlSchema(namespace = DIGIPOST_DATATYPES_NAMESPACE, elementFormDefault = jakarta.xml.bind.annotation.XmlNsForm.QUALIFIED)
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlJavaTypeAdapter(ZonedDateTimeXmlAdapter.class)
+@DataTypePackage
+package no.digipost.api.datatypes.types.signing;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlSchema;
+import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import no.digipost.api.datatypes.documentation.DataTypePackage;
+import no.digipost.api.datatypes.marshalling.ZonedDateTimeXmlAdapter;
+
+import static no.digipost.api.datatypes.marshalling.DataTypesJAXBContext.DIGIPOST_DATATYPES_NAMESPACE;
+

--- a/src/main/resources/no/digipost/api/datatypes/types/jaxb.index
+++ b/src/main/resources/no/digipost/api/datatypes/types/jaxb.index
@@ -15,6 +15,9 @@ Inkasso
 share.ShareDocumentsRequest
 share.ShareDocumentsRequestSharingStopped
 share.ShareDocumentsRequestDocumentsShared
+signing.SigningRequest
+signing.SigningCompletedBy
+signing.SigningRejectedBy
 verifiableCredential.VerifiableCredentialNotice
 verifiableCredential.VerifiablePresentationNotice
 openingreceipt.OpeningReceipt

--- a/src/test/java/no/digipost/api/datatypes/ComplementByTest.java
+++ b/src/test/java/no/digipost/api/datatypes/ComplementByTest.java
@@ -6,6 +6,9 @@ import no.digipost.api.datatypes.types.invoice.Invoice;
 import no.digipost.api.datatypes.types.invoice.InvoicePayment;
 import no.digipost.api.datatypes.types.pickup.PickupNotice;
 import no.digipost.api.datatypes.types.pickup.PickupNoticeStatus;
+import no.digipost.api.datatypes.types.signing.SigningCompletedBy;
+import no.digipost.api.datatypes.types.signing.SigningRejectedBy;
+import no.digipost.api.datatypes.types.signing.SigningRequest;
 import org.junit.jupiter.api.Test;
 
 import static co.unruly.matchers.Java8Matchers.where;
@@ -40,5 +43,22 @@ class ComplementByTest {
     void kan_komplementere_fakturadomene() {
         assertThat(Invoice.EXAMPLE, where(s -> s.getTypeIdentifier().canBeComplementedBy(InvoicePayment.EXAMPLE)));
         assertThat(Inkasso.EXAMPLE, where(s -> s.getTypeIdentifier().canBeComplementedBy(InvoicePayment.EXAMPLE)));
+    }
+
+    @Test
+    void kan_komplementere_signering_med_hendelser() {
+        assertThat(SigningRequest.EXAMPLE, where(s -> s.getTypeIdentifier().canBeComplementedBy(SigningCompletedBy.EXAMPLE)));
+        assertThat(SigningRequest.EXAMPLE, where(s -> s.getTypeIdentifier().canBeComplementedBy(SigningRejectedBy.EXAMPLE)));
+    }
+
+    @Test
+    void signering_fullfort_av_signatar_kan_komplementeres_med_ny_fullfort_av_signatar() {
+        assertThat(SigningCompletedBy.EXAMPLE, where(s -> s.getTypeIdentifier().canBeComplementedBy(SigningCompletedBy.EXAMPLE)));
+    }
+
+    @Test
+    void signering_avvist_av_signatar_kan_ikke_komplementeres_videre() {
+        assertThat(SigningRejectedBy.EXAMPLE, whereNot(s -> s.getTypeIdentifier().canBeComplementedBy(SigningRejectedBy.EXAMPLE)));
+        assertThat(SigningRejectedBy.EXAMPLE, whereNot(s -> s.getTypeIdentifier().canBeComplementedBy(SigningCompletedBy.EXAMPLE)));
     }
 }


### PR DESCRIPTION
Dette er datatyper som skal gi metadata på meldinger for å støtte opp under Signering i Digipost.

Disse er i første omgang ment for intern bruk, men denne pakken skiller ikke på intern og ekstern bruk. Det kommer guards i Digipost/digipost for å sikre dette.

På sikt kan denne tenkes brukt av eksterne API-konsumenter, som kan tenke seg å lage Signeringsoppdrag i Digipost over API. Den dagen er ikke idag, men det er en spennede framtidsmulighet.